### PR TITLE
Show repository name in multiqueue

### DIFF
--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -51,6 +51,9 @@
                 <tr>
                     <th class="hide">Sort key</th>
                     <th><input type="checkbox"></th>
+                    {% if multiple %}
+                        <th>Repository</th>
+                    {% endif %}
                     <th>#</th>
                     <th>Status</th>
                     <th>Priority</th>
@@ -67,6 +70,9 @@
                 <tr>
                     <td class="hide">{{loop.index}}</td>
                     <td><input type="checkbox" data-num="{{state.num}}"></td>
+                    {% if multiple %}
+                        <td><a href="{{state.repo_url}}">{{state.repo}}</a></td>
+                    {% endif %}
                     <td><a href="{{state.url}}">{{state.num}}</a></td>
                     <td class="{{state.status}}">{{state.status}}{{state.status_ext}}</td>
                     <td>{{state.priority}}</td>

--- a/homu/server.py
+++ b/homu/server.py
@@ -43,11 +43,14 @@ def queue(repo_label):
     logger = g.logger.getChild('queue')
 
     lazy_debug(logger, lambda: 'repo_label: {}'.format(repo_label))
-
+    multiple = False
     if repo_label == 'all':
         labels = g.repos.keys()
+        multiple = True
     else:
         labels = repo_label.split('+')
+
+    multiple = multiple or (len(labels) > 1)
 
     states = []
     for label in labels:
@@ -68,6 +71,8 @@ def queue(repo_label):
             'head_ref': state.head_ref,
             'mergeable': 'yes' if state.mergeable is True else 'no' if state.mergeable is False else '',
             'assignee': state.assignee,
+            'repo': state.name,
+            'repo_url': 'https://github.com/{}/{}'.format(state.owner, state.name),
         })
 
     return g.tpls['queue'].render(
@@ -78,6 +83,7 @@ def queue(repo_label):
         approved = len([x for x in pull_states if x.approved_by]),
         rolled_up = len([x for x in pull_states if x.rollup]),
         failed = len([x for x in pull_states if x.status == 'failure' or x.status == 'error']),
+        multiple = multiple,
     )
 
 @get('/callback')


### PR DESCRIPTION

PR ported from [118](https://github.com/barosl/homu/pull/118). Originally submitted by @Manishearth on Tue Dec 15 04:11:22 2015. 

------------------------------------------------------------------------------

Useful for sorting and quickly checking visually.

Tested for servo, seems to work.

r? @barosl

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/homu/4)
<!-- Reviewable:end -->
