### PR TITLE
Allow multiple types of builders

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -75,7 +75,7 @@ secret = ""
 #token = ""
 
 ## Use the Status API
-#[repo.NAME.status]
+#[repo.NAME.status.LABEL]
 #
 ## String label set by status updates
 #context = ""

--- a/homu/server.py
+++ b/homu/server.py
@@ -390,10 +390,11 @@ def github():
         except ValueError:
             return 'OK'
 
-        if 'status' not in state.build_res:
-            return 'OK'
-
-        if info['context'] != repo_cfg['status']['context']:
+        status_name = ""
+        for name, value in repo_cfg['status'].items():
+            if 'context' in value and value['context'] == info['context']:
+                status_name = name
+        if status_name is "":
             return 'OK'
 
         if info['state'] == 'pending':
@@ -403,7 +404,7 @@ def github():
             if row['name'] == state.base_ref:
                 return 'OK'
 
-        report_build_res(info['state'] == 'success', info['target_url'], 'status', state, logger, repo_cfg)
+        report_build_res(info['state'] == 'success', info['target_url'], 'status-' + status_name, state, logger, repo_cfg)
 
     return 'OK'
 


### PR DESCRIPTION
This currently works for travis-enabled repos, I have not tried it yet with Servo (but it looks like it should just work).

It temporarily disables the travis-exemption feature in homu, since we don't use it. I'll fix it up in a bit. (If we want to use it, we have to switch the `[repo.foo.travis]` sections with `[repo.foo.status.travis] context = 'continuous-integration/travis-ci/push'`)

To work, it needs https://github.com/servo/servo/issues/9884 on Servo, and https://github.com/servo/saltfs/issues/232 on saltfs.

The `/github` hook for any repo that wants to use this needs to be updated so that it sends the "status" event type.

cc @larsbergstrom

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/homu/13)
<!-- Reviewable:end -->
