### PR TITLE
Add a link to the GitHub repository for queue

### DIFF
--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -30,7 +30,7 @@
         </style>
     </head>
     <body>
-        <h1>Homu queue - {{repo_label}}</h1>
+        <h1>Homu queue - {% if repo_url %}<a href="{{repo_url}}" target="_blank">{{repo_label}}</a>{% else %}{{repo_label}}{% endif %}</h1>
 
         <p>
             <button type="button" id="rollup">Create a rollup</button>

--- a/homu/server.py
+++ b/homu/server.py
@@ -57,9 +57,13 @@ def queue(repo_label):
     if repo_label == 'all':
         labels = g.repos.keys()
         multiple = True
+        repo_url = None
     else:
         labels = repo_label.split('+')
         multiple = len(labels) > 1
+        repo_url = 'https://github.com/{}/{}'.format(
+            g.cfg['repo'][repo_label]['owner'],
+            g.cfg['repo'][repo_label]['name'])
 
     states = []
     for label in labels:
@@ -88,6 +92,7 @@ def queue(repo_label):
         })
 
     return g.tpls['queue'].render(
+        repo_url=repo_url,
         repo_label=repo_label,
         states=rows,
         oauth_client_id=g.cfg['github']['app_client_id'],


### PR DESCRIPTION
This is an alternate implementation of PR #8. If the user is looking at the special "all" queue page no link will be shown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/25)
<!-- Reviewable:end -->
