### PR TITLE
Try builds should be able to use a different branch than auto

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -560,15 +560,13 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
     repo_cfg = repo_cfgs[state.repo_label]
 
     builders = []
+    branch = 'try' if state.try_ else 'auto'
+    branch = repo_cfg.get('branch', {}).get(branch, branch)
     if 'buildbot' in repo_cfg:
-        branch = 'try' if state.try_ else 'auto'
-        branch = repo_cfg.get('branch', {}).get(branch, branch)
         builders += repo_cfg['buildbot']['try_builders' if state.try_ else 'builders']
     if 'travis' in repo_cfg:
-        branch = repo_cfg.get('branch', {}).get('auto', 'auto')
         builders += ['travis']
     if 'status' in repo_cfg:
-        branch = repo_cfg.get('branch', {}).get('auto', 'auto')
         builders += ['status-' + key for key, value in repo_cfg['status'].items() if 'context' in value]
     if len(builders) is 0:
         raise RuntimeError('Invalid configuration')


### PR DESCRIPTION
There is a race condition on all of our CI systems when there is a build queue
and multiple builds (e.g., try and auto) pushing to the same brach. If one
build is pushed, a CI is queued but not started, and then another build is
pushed to the same branch, when the queued CI job begins executing, it will
fail to find the git commit hash since it is no longer in the branch.

Fixes #23 

r? @Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/26)
<!-- Reviewable:end -->
