### PR TITLE
Don't use the PR body in the homu merge message

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -445,12 +445,11 @@ def create_merge(state, repo_cfg, branch, git_cfg):
 
     state.refresh()
 
-    merge_msg = 'Auto merge of #{} - {}, r={}\n\n{}\n\n{}'.format(
+    merge_msg = 'Auto merge of #{} - {}, r={}\n\n{}'.format(
         state.num,
         state.head_ref,
         '<try>' if state.try_ else state.approved_by,
         state.title,
-        state.body,
     )
 
     desc = 'Merge conflict'


### PR DESCRIPTION
This is not optimal, but worth discussing it.

Probably we could be smarter and use a regexp to keep just the `Fixes|Closes|Adresses #xxx` messages.

Fixes https://github.com/servo/servo/issues/11153
Fixes https://github.com/servo/homu/issues/36

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/37)

<!-- Reviewable:end -->
