### PR TITLE
Support overriding git username+email in config

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -20,6 +20,12 @@ app_client_secret = ""
 #ssh_key = """
 #"""
 
+# By default, Homu extracts the name+email from the Github account.  However,
+# you may want to use a private email for the account, and associate the commits
+# with a public email address.
+#user = "Some Cool Project Bot"
+#email = "coolprojectbot-devel@example.com"
+
 [web]
 
 # The port homu listens on


### PR DESCRIPTION
When one creates an automated github account for Homu, it may be
desirable to have a private email associated with the github account.

Currently it seems e.g. the Servo project's bors-servo does not have a
public email instance, but we're relying on the app ID being granted
access to the `user` scope to see it, so Homu ends up writing
lbergstrom's email into the commit messages, even though it's not
public.

I suspect most people will prefer what this patch offers, which allows
directly setting the git user/email (rather than retrieving it from
github), so one can easily use e.g. a public mailing list for the
commits.  Which would be a more useful place to send mail generally.
Anyone who wants to contact the bot owner should be able to figure out
how to do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/38)
<!-- Reviewable:end -->
