### PR TITLE
Explain delegation more clearly

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -347,7 +347,9 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
             state.save()
 
             if realtime:
-                state.add_comment(':v: @{} can now approve this pull request'.format(state.delegate))
+                msg = ":v: @{}, you\'re now a reviewer for this PR!".format(state.delegate))
+                msg += "Once the code looks good, approve the PR by commenting '@bors-servo r=@{}'".format(state.assignee)
+                state.add_comment(msg)
 
         elif word == 'delegate-':
             state.delegate = ''


### PR DESCRIPTION
Confusion happened in https://github.com/servo/rust-harfbuzz/pull/63 because Homu failed to explain what "approval" meant in the current context.

```
196 11:17:25 < edunham> jack: ok, how should we word homu's delegate message... "@NAME, @NAME has delegated reviewing this PR to you! Please review the code then approve it 
                        with '@bors-servo r=NAME' once you think it's ready to merge"?
196 11:18:31 < vlad> edunham: that would have made it clearer to me
196 11:18:36 < vlad> it's too bad there's no way to disable manual merges
196 11:20:30 < jdm_> edunham: delegating can also be used after the review is complete and some minor changes are still required; maybe "@DELEGATE_TARGET, @DELEGATE_SOURCE 
                     has granted you the ability to merge this PR! When the code is reviewed and ready to merge, please approve it with `@bors-servo r=NAME_OF_REVIEWER`."
196 11:21:05 < jdm_> we could conceivably use the name of the assignee instead of NAME_OF_REVIEWER
196 11:21:54 < jdm_> or we could check if the PR author == the delegate target, and suggest the name of the delegate source in that case
196 11:21:59 < jdm_> that seems like a reasonable heuristic
```

I'm not totally sure whether `assignee` is the right person to `r=`; is there a better value available in the state at delegation time that I should be using instead?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/53)

<!-- Reviewable:end -->
