### PR TITLE
Add status-based test exemptions

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -90,3 +90,8 @@ secret = ""
 #
 ## String label set by status updates
 #context = ""
+#
+## Equivalent context to look for on the PR itself if checking whether the
+## build should be exempted. If omitted, looks for the same context. This is
+## only used if status_based_exemption is true.
+#pr_context = ""

--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -50,6 +50,11 @@ try_users = []
 # Auto-squash commits. Requires the local Git command
 #autosquash = true
 
+# If the PR already has the same success statuses that we expect on the auto
+# branch, then push directly to branch if safe to do so. Requires the local Git
+# command.
+#status_based_exemption = false
+
 ## branch names (these settings here are the defaults)
 #[repo.NAME.branch]
 #

--- a/homu/server.py
+++ b/homu/server.py
@@ -123,7 +123,8 @@ def callback():
         })
     except Exception as ex:
         logger.warn('/callback encountered an error during github oauth callback')
-        lazy_debug(logger, lambda: 'github oauth callback err: {}'.format(ex))
+        s = 'github oauth callback err: {}'.format(ex)
+        lazy_debug(logger, lambda: s)
         abort(502, 'Bad Gateway')
 
     args = urllib.parse.parse_qs(res.text)
@@ -532,7 +533,8 @@ def buildbot():
                         ))
                     except Exception as ex:
                         logger.warn('/buildbot encountered an error during github logs request')
-                        lazy_debug(logger, lambda: 'buildbot logs err: {}'.format(ex))
+                        s = 'buildbot logs err: {}'.format(ex)
+                        lazy_debug(logger, lambda: s)
                         abort(502, 'Bad Gateway')
 
                     mat = INTERRUPTED_BY_HOMU_RE.search(res.text)

--- a/homu/server.py
+++ b/homu/server.py
@@ -123,8 +123,8 @@ def callback():
         })
     except Exception as ex:
         logger.warn('/callback encountered an error during github oauth callback')
-        s = 'github oauth callback err: {}'.format(ex)
-        lazy_debug(logger, lambda: s)
+        # probably related to https://gitlab.com/pycqa/flake8/issues/42
+        lazy_debug(logger, lambda: 'github oauth callback err: {}'.format(ex)) # NOQA
         abort(502, 'Bad Gateway')
 
     args = urllib.parse.parse_qs(res.text)
@@ -533,8 +533,8 @@ def buildbot():
                         ))
                     except Exception as ex:
                         logger.warn('/buildbot encountered an error during github logs request')
-                        s = 'buildbot logs err: {}'.format(ex)
-                        lazy_debug(logger, lambda: s)
+                        # probably related to https://gitlab.com/pycqa/flake8/issues/42
+                        lazy_debug(logger, lambda: 'buildbot logs err: {}'.format(ex)) # NOQA
                         abort(502, 'Bad Gateway')
 
                     mat = INTERRUPTED_BY_HOMU_RE.search(res.text)


### PR DESCRIPTION
These patches bring status-based test exemptions similar to what we already have for Travis CI.

In most cases, the same tests are run on both PRs and the auto branch. If these tests output a commit status, we can be a bit smarter about testing. For example, if the PR is fully rebased and already passed the statuses we would expect on the auto branch, then there's no point in retesting it.

The first two patches do some clean ups and refactoring in preparation for the third patch, which introduces the `status_based_exemption` setting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/54)
<!-- Reviewable:end -->
