### PR TITLE
Reset success state on r+

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -318,6 +318,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
             if sha_cmp(cur_sha, state.head_sha):
                 state.approved_by = approver
                 state.try_ = False
+                state.set_status('')
 
                 state.save()
             elif realtime and username != my_username:


### PR DESCRIPTION
This makes `r+` imply `retry` in the case of PRs that previously had a successful try build.

Currently, if a PR has a successful try build, its status is set to success. When it gets r+d, this
status does not change, so it never gets tested.

This PR changes it so that the status is cleared. This only is done once we're sure that the PR hasn't been approved already (otherwise we might lose failure info).

r? @cgwalters

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/63)

<!-- Reviewable:end -->
