### PR TITLE
Add (optional) synchronize_all on startup

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -31,6 +31,9 @@ app_client_secret = ""
 # The port homu listens on
 port = 54856
 
+# Synchronize all open PRs on startup
+#sync_on_start = false
+
 # An example configuration for repository (there can be many of these)
 [repo.NAME]
 

--- a/homu/git_helper.py
+++ b/homu/git_helper.py
@@ -10,5 +10,6 @@ def main():
     args = ['ssh', '-i', SSH_KEY_FILE, '-S', 'none'] + sys.argv[1:]
     os.execvp('ssh', args)
 
+
 if __name__ == '__main__':
     main()

--- a/homu/main.py
+++ b/homu/main.py
@@ -45,6 +45,7 @@ def buildbot_sess(repo_cfg):
 
     sess.get(repo_cfg['buildbot']['url'] + '/logout', allow_redirects=False)
 
+
 db_query_lock = Lock()
 
 
@@ -1240,6 +1241,7 @@ def main():
     Thread(target=check_timeout, args=[states, queue_handler]).start()
 
     queue_handler()
+
 
 if __name__ == '__main__':
     main()

--- a/homu/server.py
+++ b/homu/server.py
@@ -22,6 +22,8 @@ bottle.BaseRequest.MEMFILE_MAX = 1024 * 1024 * 10
 
 class G:
     pass
+
+
 g = G()
 
 
@@ -710,6 +712,7 @@ def admin():
         return 'OK'
 
     return 'Unrecognized command'
+
 
 def start(cfg, states, queue_handler, repo_cfgs, repos, logger, buildbot_slots, my_username, db, repo_labels, mergeable_que, gh):
     env = jinja2.Environment(

--- a/homu/server.py
+++ b/homu/server.py
@@ -645,6 +645,21 @@ def synch(user_gh, state, repo_label, repo_cfg, repo):
     return 'Synchronizing {}...'.format(repo_label)
 
 
+def synch_all():
+    @retry(wait_exponential_multiplier=1000, wait_exponential_max=600000)
+    def sync_repo(repo_label, g):
+        try:
+            synchronize(repo_label, g.repo_cfgs[repo_label], g.logger, g.gh, g.states, g.repos, g.db, g.mergeable_que, g.my_username, g.repo_labels)
+        except:
+            print('* Error while synchronizing {}'.format(repo_label))
+            traceback.print_exc()
+            raise
+
+    for repo_label in g.repos:
+        sync_repo(repo_label, g)
+    print('* Done synchronizing all')
+
+
 @post('/admin')
 def admin():
     if request.json['secret'] != g.cfg['web']['secret']:
@@ -690,21 +705,7 @@ def admin():
         return 'OK'
 
     elif request.json['cmd'] == 'sync_all':
-        @retry(wait_exponential_multiplier=1000, wait_exponential_max=600000)
-        def sync_repo(repo_label, g):
-            try:
-                synchronize(repo_label, g.repo_cfgs[repo_label], g.logger, g.gh, g.states, g.repos, g.db, g.mergeable_que, g.my_username, g.repo_labels)
-            except:
-                print('* Error while synchronizing {}'.format(repo_label))
-                traceback.print_exc()
-                raise
-
-        def sync_all_repos():
-            for repo_label in g.repos:
-                sync_repo(repo_label, g)
-            print('* Done synchronizing all')
-
-        Thread(target=sync_all_repos).start()
+        Thread(target=synch_all).start()
 
         return 'OK'
 
@@ -732,6 +733,9 @@ def start(cfg, states, queue_handler, repo_cfgs, repos, logger, buildbot_slots, 
     g.repo_labels = repo_labels
     g.mergeable_que = mergeable_que
     g.gh = gh
+
+    # Synchronize all PR data on startup
+    Thread(target=synch_all).start()
 
     try:
         run(host=cfg['web'].get('host', ''), port=cfg['web']['port'], server='waitress')

--- a/homu/server.py
+++ b/homu/server.py
@@ -735,7 +735,8 @@ def start(cfg, states, queue_handler, repo_cfgs, repos, logger, buildbot_slots, 
     g.gh = gh
 
     # Synchronize all PR data on startup
-    Thread(target=synch_all).start()
+    if cfg['web'].get('sync_on_start', False):
+        Thread(target=synch_all).start()
 
     try:
         run(host=cfg['web'].get('host', ''), port=cfg['web']['port'], server='waitress')

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         'requests',
         'bottle',
         'waitress',
+        'retrying',
     ],
     package_data={
         'homu': [


### PR DESCRIPTION
tl;dr this PR adds a config option that kicks off the admin `synch_all` task on startup

When running [homu-on-heroku](https://github.com/japaric/homu-on-heroku/), it turns out that Heroku restarts the webapp worker and wipes out the SQLite database of existing PRs. To work around that, I added a configuration option that tells Homu to synchronize all PRs at startup, and sent a [matching PR to homu-on-heroku](https://github.com/japaric/homu-on-heroku/pull/8) to add support for the option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/66)
<!-- Reviewable:end -->
