### PR TITLE
Pass --no-ff for local merge

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -545,7 +545,8 @@ def create_merge(state, repo_cfg, branch, git_cfg, ensure_merge_equal=False):
                 try:
                     utils.logged_call(git_cmd('-c', 'user.name=' + git_cfg['name'],
                                               '-c', 'user.email=' + git_cfg['email'],
-                                              'merge', 'heads/homu-tmp', '-m', merge_msg))
+                                              'merge', 'heads/homu-tmp',
+                                              '--no-ff', '-m', merge_msg))
                 except subprocess.CalledProcessError:
                     pass
                 else:


### PR DESCRIPTION
This ensures that the merge commit always shows up

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/68)
<!-- Reviewable:end -->
