### PR TITLE
server: Default host to '*'

### DIFF
--- a/homu/server.py
+++ b/homu/server.py
@@ -742,7 +742,7 @@ def start(cfg, states, queue_handler, repo_cfgs, repos, logger, buildbot_slots, 
         Thread(target=synch_all).start()
 
     try:
-        run(host=cfg['web'].get('host', ''), port=cfg['web']['port'], server='waitress')
+        run(host=cfg['web'].get('host', '*'), port=cfg['web']['port'], server='waitress')
     except OSError as e:
         print(e, file=sys.stderr)
         os._exit(1)


### PR DESCRIPTION
I'm running Homu in an OpenShift v3/Kubernetes cluster, and for some reason
I didn't fully debug, the default configuration for bottle with `host=''"`
appears to try to look up the hostname to determine the bind interface.

I think this works with "host networking" typically, but it won't
in a lot of containerized setups.

What we really want to do by default is use `*` which binds to all interfaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/72)
<!-- Reviewable:end -->
