### PR TITLE
utils: Print stderr from child processes by default

### DIFF
--- a/homu/utils.py
+++ b/homu/utils.py
@@ -65,7 +65,7 @@ def lazy_debug(logger, f):
 
 def logged_call(args):
     try:
-        subprocess.check_call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.check_call(args, stdout=subprocess.DEVNULL, stderr=None)
     except subprocess.CalledProcessError:
         print('* Failed to execute command: {}'.format(args))
         raise


### PR DESCRIPTION
If for example `git fetch` fails due to a permission error, the github.com ssh
key changing, a segfault inside one of the helper binaries or whatever - I
really want to see that by default.

Currently when running in Kubernetes/Docker I see a Python stack trace, but not
the actual error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/75)
<!-- Reviewable:end -->
