### PR TITLE
Implement tree closure

### DIFF
--- a/homu/html/index.html
+++ b/homu/html/index.html
@@ -23,7 +23,7 @@
 
         <ul class="repos">
             {% for repo in repos %}
-            <li><a href="queue/{{repo}}">{{repo}}</a></li>
+            <li><a href="queue/{{repo.repo_label}}">{{repo.repo_label}}</a> {% if repo.treeclosed >= 0 %} [TREE CLOSED] {% endif %}</li>
             {% endfor %}
         </ul>
 

--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title>Homu queue - {{repo_label}}</title>
+        <title>Homu queue - {{repo_label}} {% if treeclosed %} [TREE CLOSED] {% endif %}</title>
         <style>
             * { font-family: sans-serif; }
             h1 { font-size: 20px; }
@@ -13,6 +13,7 @@
             td, th { border: 2px solid white; padding: 5px; font-size: 13px; }
             tr:nth-child(even) { background: #ddd; }
 
+            .treeclosed { color: grey }
             .success { background-color: #80C0F0; }
             .failure, .error { background-color: #F08080; }
             .pending { background-color: #F0DE57; }
@@ -30,7 +31,7 @@
         </style>
     </head>
     <body>
-        <h1>Homu queue - {% if repo_url %}<a href="{{repo_url}}" target="_blank">{{repo_label}}</a>{% else %}{{repo_label}}{% endif %}</h1>
+        <h1>Homu queue - {% if repo_url %}<a href="{{repo_url}}" target="_blank">{{repo_label}}</a>{% else %}{{repo_label}}{% endif %} {% if treeclosed %} [TREE CLOSED below priority {{treeclosed}}] {% endif %}</h2>
 
         <p>
             <button type="button" id="rollup">Create a rollup</button>
@@ -67,7 +68,7 @@
 
             <tbody>
                 {% for state in states %}
-                <tr>
+                <tr class="{{state.greyed}}">
                     <td class="hide">{{loop.index}}</td>
                     <td><input type="checkbox" data-num="{{state.num}}"></td>
                     {% if multiple %}

--- a/homu/main.py
+++ b/homu/main.py
@@ -77,6 +77,9 @@ class Repository:
         if value > 0:
             db_query(self.db, 'INSERT INTO repos (repo, treeclosed) VALUES (?, ?)', [self.repo_label, value])
 
+    def __lt__(self, other):
+        return self.gh < other.gh
+
 class PullReqState:
     num = 0
     priority = 0
@@ -982,6 +985,8 @@ def process_queue(states, repos, repo_cfgs, logger, buildbot_slots, db, git_cfg)
         repo_states = sorted(states[repo_label].values())
 
         for state in repo_states:
+            if state.priority < repo.treeclosed:
+                break
             if state.status == 'pending' and not state.try_:
                 break
 

--- a/homu/main.py
+++ b/homu/main.py
@@ -55,11 +55,13 @@ def db_query(db, *args):
     with db_query_lock:
         db.execute(*args)
 
+
 class Repository:
     treeclosed = -1
     gh = None
     label = None
     db = None
+
     def __init__(self, gh, repo_label, db):
         self.gh = gh
         self.repo_label = repo_label
@@ -79,6 +81,7 @@ class Repository:
 
     def __lt__(self, other):
         return self.gh < other.gh
+
 
 class PullReqState:
     num = 0
@@ -1088,6 +1091,7 @@ def check_timeout(states, queue_handler):
         finally:
             time.sleep(3600)
 
+
 def synchronize(repo_label, repo_cfg, logger, gh, states, repos, db, mergeable_que, my_username, repo_labels):
     logger.info('Synchronizing {}...'.format(repo_label))
 
@@ -1268,7 +1272,6 @@ def main():
 
         repo_states = {}
         repos[repo_label] = Repository(None, repo_label, db)
-
 
         db_query(db, 'SELECT num, head_sha, status, title, body, head_ref, base_ref, assignee, approved_by, priority, try_, rollup, delegate, merge_sha FROM pull WHERE repo = ?', [repo_label])
         for num, head_sha, status, title, body, head_ref, base_ref, assignee, approved_by, priority, try_, rollup, delegate, merge_sha in db.fetchall():

--- a/homu/main.py
+++ b/homu/main.py
@@ -274,7 +274,15 @@ class AuthState(IntEnum):
     NONE = 1
 
 
-def verify_auth(username, repo_cfg, state, auth, realtime):
+def verify_auth(username, repo_cfg, state, auth, realtime, my_username):
+    # In some cases (e.g. non-fully-qualified r+) we recursively talk to ourself
+    # via a hidden markdown comment in the message. This is so that
+    # when re-synchronizing after shutdown we can parse these comments
+    # and still know the SHA for the approval.
+    #
+    # So comments from self should always be allowed
+    if username == my_username:
+        return True
     is_reviewer = False
     auth_collaborators = repo_cfg.get('auth_collaborators', False)
     if auth_collaborators:
@@ -311,9 +319,6 @@ PORTAL_TURRET_IMAGE = "https://cloud.githubusercontent.com/assets/1617736/222229
 
 
 def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, realtime=False, sha=''):
-    # Skip parsing notifications that we created
-    if username == my_username:
-        return False
 
     state_changed = False
 
@@ -323,7 +328,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
     for i, word in reversed(list(enumerate(words))):
         found = True
         if word == 'r+' or word.startswith('r='):
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime, my_username):
                 continue
 
             if not sha and i + 1 < len(words):
@@ -395,7 +400,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
                     state.add_comment(':pushpin: Commit {:.7} has been approved by `{}`\n\n<!-- @{} r={} {} -->'.format(state.head_sha, approver, my_username, approver, state.head_sha))
 
         elif word == 'r-':
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime, my_username):
                 continue
 
             state.approved_by = ''
@@ -403,7 +408,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
             state.save()
 
         elif word.startswith('p='):
-            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime, my_username):
                 continue
             try:
                 state.priority = int(word[len('p='):])
@@ -413,7 +418,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
             state.save()
 
         elif word.startswith('delegate='):
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime, my_username):
                 continue
 
             state.delegate = word[len('delegate='):]
@@ -424,13 +429,13 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
 
         elif word == 'delegate-':
             # TODO: why is this a TRY?
-            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime, my_username):
                 continue
             state.delegate = ''
             state.save()
 
         elif word == 'delegate+':
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime, my_username):
                 continue
 
             state.delegate = state.get_repo().pull_request(state.num).user.login
@@ -440,12 +445,12 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
                 state.add_comment(':v: @{} can now approve this pull request'.format(state.delegate))
 
         elif word == 'retry' and realtime:
-            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime, my_username):
                 continue
             state.set_status('')
 
         elif word in ['try', 'try-'] and realtime:
-            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime, my_username):
                 continue
             state.try_ = word == 'try'
 
@@ -455,14 +460,14 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
             state.save()
 
         elif word in ['rollup', 'rollup-']:
-            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime, my_username):
                 continue
             state.rollup = word == 'rollup'
 
             state.save()
 
         elif word == 'force' and realtime:
-            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime, my_username):
                 continue
             if 'buildbot' in repo_cfg:
                 with buildbot_sess(repo_cfg) as sess:
@@ -486,7 +491,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
                 state.add_comment(':bomb: Buildbot returned an error: `{}`'.format(err))
 
         elif word == 'clean' and realtime:
-            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.TRY, realtime, my_username):
                 continue
             state.merge_sha = ''
             state.init_build_res([])
@@ -495,7 +500,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
         elif word == 'hello?' or word == 'ping':
             state.add_comment(":sleepy: I'm awake I'm awake")
         elif word.startswith('treeclosed='):
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime, my_username):
                 continue
             try:
                 treeclosed = int(word[len('treeclosed='):])
@@ -504,7 +509,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states, *, 
                 pass
             state.save()
         elif word == 'treeclosed-':
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime):
+            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER, realtime, my_username):
                 continue
             state.change_treeclosed(-1)
             state.save()

--- a/homu/server.py
+++ b/homu/server.py
@@ -89,7 +89,7 @@ def queue(repo_label):
 
         if treeclosed:
             status_ext += ' [TREE CLOSED]'
- 
+
         rows.append({
             'status': state.get_status(),
             'status_ext': status_ext,

--- a/homu/server.py
+++ b/homu/server.py
@@ -37,7 +37,7 @@ def find_state(sha):
 
 
 def get_repo(repo_label, repo_cfg):
-    repo = g.repos[repo_label]
+    repo = g.repos[repo_label].gh
     if not repo:
         g.repos[repo_label] = repo = g.gh.repository(repo_cfg['owner'], repo_cfg['name'])
 


### PR DESCRIPTION
fixes #85 (also drive-by fixes #86)

This is implemented as `@bors-servo treeclosed=<number>`, which closes the tree for PRs below a priority value. `@bors-servo treeclosed-` (or `@bors-servo treeclosed=-1`) restores the tree.

cc @jdm @cgwalters

r? @edunham

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/87)
<!-- Reviewable:end -->
