### PR TITLE
log if locale is not compatible with unicode

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 from itertools import chain
 from queue import Queue
 import os
+import sys
 from enum import IntEnum
 import subprocess
 from .git_helper import SSH_KEY_FILE
@@ -1186,6 +1187,9 @@ def main():
     logger = logging.getLogger('homu')
     logger.setLevel(logging.DEBUG if args.verbose else logging.INFO)
     logger.addHandler(logging.StreamHandler())
+
+    if sys.getfilesystemencoding() == 'ascii':
+        logger.info('You need to set a locale compatible with unicode or homu will choke on Unicode in PR descriptions/titles. See http://stackoverflow.com/a/27931669')
 
     try:
         with open(args.config) as fp:


### PR DESCRIPTION
Not a fix, but at least a early report for https://github.com/servo/homu/issues/90

@frewsxcv, Did I write this correctly? Does it make sense to report this early?
This is a quick first draft, suggestions and improvements are welcome.

@alexcrichton, Is the rust infrastructure updated to not have #90? Should I make a pr to fix it somewhere?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/91)
<!-- Reviewable:end -->
