### PR TITLE
Allow a limited set of build statuses for try builds.

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -112,6 +112,9 @@ secret = ""
 ## String label set by status updates
 #context = ""
 #
+## Boolean which indicates whether the builder is included in try builds (defaults to true)
+#try = false
+#
 ## Equivalent context to look for on the PR itself if checking whether the
 ## build should be exempted. If omitted, looks for the same context. This is
 ## only used if status_based_exemption is true.

--- a/homu/main.py
+++ b/homu/main.py
@@ -1084,6 +1084,9 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
         for key, value in repo_cfg['status'].items():
             context = value.get('context')
             if context is not None:
+                if state.try_ and not value.get('try', True):
+                    # Skip this builder for tries.
+                    continue
                 builders += ['status-' + key]
                 # We have an optional fast path if the Travis test passed
                 # for a given commit and master is unchanged, we can do


### PR DESCRIPTION
Rust has started using try builds to get artifacts for running [cargobomb](https://github.com/brson/cargobomb]). But try builds only trigger travis and not appveyor, so it things they timeout when the in fact succeed.

This allows configuring individual statuses to be skipped for try builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/124)
<!-- Reviewable:end -->
