### PR TITLE
Move `max_priority` to the global section.

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -1,3 +1,6 @@
+# Priority values above max_priority will be refused.
+max_priority = 9001
+
 [github]
 
 # Information for securely interacting with GitHub. These are found/generated
@@ -9,9 +12,6 @@ access_token = ""
 # A GitHub oauth application for this instance of homu:
 app_client_id = ""
 app_client_secret = ""
-
-# Priority values above max_priority will be refused.
-max_priority = 9001
 
 [git]
 


### PR DESCRIPTION
This appears to be where it is actually read from.

Is suspect servo's homu's configuration needs to be updated for this to work properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/126)
<!-- Reviewable:end -->
