### PR TITLE
Stop mentioning user "9001" when priority limit is reached.

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -527,7 +527,7 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
             if pvalue > global_cfg['max_priority']:
                 if realtime:
                     state.add_comment(
-                        ':stop_sign: Priority higher than @{} is ignored.'
+                        ':stop_sign: Priority higher than {} is ignored.'
                         .format(global_cfg['max_priority'])
                     )
                 continue


### PR DESCRIPTION
Example of problematic comments:

* https://github.com/rust-lang/rust/pull/44115#issuecomment-325206478
* https://github.com/rust-lang/rust/pull/43710#issuecomment-322597421

cc #114 @edunham.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/132)
<!-- Reviewable:end -->
