### PR TITLE
retry if 422 Update is not a fast forward

### DIFF
--- a/homu/utils.py
+++ b/homu/utils.py
@@ -8,7 +8,7 @@ import requests
 import time
 
 
-def github_set_ref(repo, ref, sha, *, force=False, auto_create=True):
+def github_set_ref(repo, ref, sha, *, force=False, auto_create=True, retry=1):
     url = repo._build_url('git', 'refs', ref, base_url=repo._api)
     data = {'sha': sha, 'force': force}
 
@@ -20,6 +20,9 @@ def github_set_ref(repo, ref, sha, *, force=False, auto_create=True):
                 return repo.create_ref('refs/' + ref, sha)
             except github3.models.GitHubError:
                 raise e
+        elif e.code == 422 and retry > 0:
+            time.sleep(5)
+            return github_set_ref(repo, ref, sha, force=force, auto_create=auto_create, retry=retry - 1)
         else:
             raise
 

--- a/homu/utils.py
+++ b/homu/utils.py
@@ -22,7 +22,12 @@ def github_set_ref(repo, ref, sha, *, force=False, auto_create=True, retry=1):
                 raise e
         elif e.code == 422 and retry > 0:
             time.sleep(5)
-            return github_set_ref(repo, ref, sha, force=force, auto_create=auto_create, retry=retry - 1)
+            return github_set_ref(repo,
+                                  ref,
+                                  sha,
+                                  force=force,
+                                  auto_create=auto_create,
+                                  retry=retry - 1)
         else:
             raise
 


### PR DESCRIPTION
As @kennytm suggested in https://github.com/rust-lang/rust/issues/43535 This is a quick fix to try and suppress the [intermittent 422 errors.](https://github.com/servo/homu/issues/24)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/134)
<!-- Reviewable:end -->
