### PR TITLE
Ensure PR status is always updated for r+ events

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -477,20 +477,16 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
 
                 state.add_comment('\n'.join(lines))
 
-            if sha_cmp(cur_sha, state.head_sha):
-                state.approved_by = approver
-                state.try_ = False
-                state.set_status('')
-
-                state.save()
-            elif realtime and username != my_username:
-                if cur_sha:
+            valid_merge_state = sha_cmp(cur_sha, state.head_sha)
+            if realtime and username != my_username:
+                if cur_sha and not valid_merge_state:
                     msg = '`{}` is not a valid commit SHA.'.format(cur_sha)
                     state.add_comment(
                         ':scream_cat: {} Please try again with `{:.7}`.'
                         .format(msg, state.head_sha)
                     )
                 else:
+                    valid_merge_state = True
                     state.add_comment(
                         ':pushpin: Commit {:.7} has been approved by `{}`\n\n<!-- @{} r={} {} -->'  # noqa
                         .format(
@@ -506,6 +502,13 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
                             ':evergreen_tree: The tree is currently closed for pull requests below priority {}, this pull request will be tested once the tree is reopened'  # noqa
                             .format(treeclosed)
                         )
+
+            if valid_merge_state
+                state.approved_by = approver
+                state.try_ = False
+                state.set_status('')
+
+                state.save()
 
         elif word == 'r-':
             if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER,


### PR DESCRIPTION
Based on reading the code, I believe the treeclosed bug occurs because the PR's approved_by field does not get updated in realtime mode. Honestly I have can't figure out why this works when the tree isn't closed, though. This change should not make anything worse, at least!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/140)
<!-- Reviewable:end -->
