### PR TITLE
Support relabeling when some event happens

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -96,6 +96,28 @@ try_users = []
 # Arbitrary secret. You can generate one with: openssl rand -hex 20
 secret = ""
 
+# Remove and add GitHub labels when some event happened.
+# See servo/homu#141 for detail.
+#
+#[repo.NAME.labels.approved]    # after homu received `r+`
+#[repo.NAME.labels.rejected]    # after homu received `r-`
+#[repo.NAME.labels.conflict]    # a merge conflict is detected
+#[repo.NAME.labels.succeed]     # test successful
+#[repo.NAME.labels.failed]      # test failed
+#[repo.NAME.labels.exempted]    # test exempted
+#[repo.NAME.labels.timed_out]   # test timed out (after 10 hours)
+#[repo.NAME.labels.interrupted] # test interrupted (buildbot only)
+#[repo.NAME.labels.try]         # after homu received `try`
+#[repo.NAME.labels.try_succeed] # try-build successful
+#[repo.NAME.labels.try_failed]  # try-build failed
+#[repo.NAME.labels.pushed]      # user pushed a commit after `r+`/`try`
+#remove = ['list', 'of', 'labels', 'to', 'remove']
+#add = ['list', 'of', 'labels', 'to', 'add']
+#unless = [
+#   'avoid', 'relabeling', 'if',
+#   'any', 'of', 'these', 'labels', 'are', 'present',
+#]
+
 # Travis integration. Don't forget to allow Travis to test the `auto` branch!
 [repo.NAME.status.travis]
 # String label set by status updates. Don't touch this unless you really know


### PR DESCRIPTION
Let Homu automatically relabel the issue when some predefined events happened. The labels can be configured through `cfg.toml` via the `[repo.NAME.labels.EVENT]` key, e.g.

```toml
# when a merge conflict is detected...
[repo.rust.labels.conflict]
# remove the `S-waiting-on-bors` and `S-waiting-on-review` labels...
remove = ['S-waiting-on-bors', 'S-waiting-on-review']
# add the `S-waiting-on-author` label...
add = ['S-waiting-on-author']
# but don't do anything if the PR is already labeled with `S-blocked`, 
# `S-waiting-on-crater` or `S-waiting-on-team`.
except = ['S-blocked', 'S-waiting-on-crater', 'S-waiting-on-team']
```

See `cfg.sample.toml` for a list of supported events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/141)
<!-- Reviewable:end -->
