### PR TITLE
Allow TEST_TIMEOUT be configured.

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -80,6 +80,10 @@ try_users = []
 # command.
 #status_based_exemption = false
 
+# Maximum test duration allowed for testing a PR in this repository.
+# Default to 10 hours.
+#timeout = 36000
+
 # Branch names. These settings are the defaults; it makes sense to leave these
 # as-is.
 #[repo.NAME.branch]

--- a/homu/main.py
+++ b/homu/main.py
@@ -34,7 +34,7 @@ STATUS_TO_PRIORITY = {
 
 INTERRUPTED_BY_HOMU_FMT = 'Interrupted by Homu ({})'
 INTERRUPTED_BY_HOMU_RE = re.compile(r'Interrupted by Homu \((.+?)\)')
-TEST_TIMEOUT = 3600 * 10
+DEFAULT_TEST_TIMEOUT = 3600 * 10
 
 global_cfg = {}
 
@@ -1168,7 +1168,8 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
         branch,
         state.merge_sha))
 
-    state.start_testing(TEST_TIMEOUT)
+    timeout = repo_cfg.get('timeout', DEFAULT_TEST_TIMEOUT)
+    state.start_testing(timeout)
 
     desc = '{} commit {} with merge {}...'.format(
         'Trying' if state.try_ else 'Testing',
@@ -1244,7 +1245,8 @@ def start_rebuild(state, repo_cfgs):
                 state.add_comment(':bomb: Failed to start rebuilding: `{}`'.format(err))  # noqa
                 return False
 
-    state.start_testing(TEST_TIMEOUT)
+    timeout = repo_cfg.get('timeout', DEFAULT_TEST_TIMEOUT)
+    state.start_testing(timeout)
 
     msg_1 = 'Previous build results'
     msg_2 = ' for {}'.format(', '.join('[{}]({})'.format(builder, url) for builder, url in succ_builders))  # noqa


### PR DESCRIPTION
Homu currently hard codes the test timeout to 10 hours. This is unnecessarily long for many projects, including Rust. Recently, there is  bug in AppVeyor or GitHub causing the status notification not delivered, and thus the queue can be stuck for 10 hours when unattended. 

This PR introduced a fix to allow the timeout be configured for each repository.

```toml
[repo.NAME]
# timeout after 3 hr 20 min
timeout = 12000
```

When the timeout is less than 1 hour, the current `check_timeout` loop will be too coarse. Therefore, I've also refactored and removed the loop in favor of a [`Timer`](https://docs.python.org/3/library/threading.html#timer-objects) object for each pending PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/142)
<!-- Reviewable:end -->
