### PR TITLE
Refactor parse_commands to add tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 /homu/__pycache__/
+/tests/__pycache__/
 /.venv/
 /cfg.toml
 /cfg.json
 /homu.egg-info/
 /main.db
 /cache
+**/*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
 install:
   - pip install flake8
   - pip install 'github3.py<1.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ python:
   - 3.5
 install:
   - pip install flake8
+  - python setup.py install
 script:
   - flake8 homu
-  - python setup.py install
   - python -m unittest discover tests
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,13 @@ python:
   - 3.5
 install:
   - pip install flake8
-  - python setup.py install
+  - pip install 'github3.py<1.0'
+  - pip install 'toml'
+  - pip install 'Jinja2'
+  - pip install 'requests'
+  - pip install 'bottle'
+  - pip install 'waitress'
+  - pip install 'retrying'
 script:
   - flake8 homu
   - python -m unittest discover tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,7 @@ install:
   - pip install flake8
 script:
   - flake8 homu
+  - python setup.py install
+  - python -m unittest discover tests
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/homu/main.py
+++ b/homu/main.py
@@ -513,7 +513,11 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
         elif word == 'delegate+':
             if not _reviewer_auth_verified:
                 continue
-            delegate_positive(state, realtime)
+            delegate_positive(state,
+                              state.get_repo().
+                              pull_request(state.num).
+                              user.login,
+                              realtime)
 
         elif word == 'retry' and realtime:
             if not _try_auth_verified():
@@ -589,10 +593,14 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
     return state_changed
 
 
+def get_portal_turret_dialog():
+    return random.choice(PORTAL_TURRET_DIALOG)
+
+
 def still_here(state):
     state.add_comment(
         ":cake: {}\n\n![]({})".format(
-            random.choice(PORTAL_TURRET_DIALOG), PORTAL_TURRET_IMAGE)
+            get_portal_turret_dialog(), PORTAL_TURRET_IMAGE)
         )
 
 
@@ -673,8 +681,8 @@ def delegate_negative(state):
     state.save()
 
 
-def delegate_positive(state, realtime):
-    state.delegate = state.get_repo().pull_request(state.num).user.login  # noqa
+def delegate_positive(state, delegate, realtime):
+    state.delegate = delegate
     state.save()
 
     if realtime:

--- a/homu/main.py
+++ b/homu/main.py
@@ -3,7 +3,6 @@ import github3
 import toml
 import json
 import re
-import functools
 from . import utils
 from .utils import lazy_debug
 import logging

--- a/homu/main.py
+++ b/homu/main.py
@@ -440,279 +440,117 @@ PORTAL_TURRET_DIALOG = ["Target acquired", "Activated", "There you are"]
 PORTAL_TURRET_IMAGE = "https://cloud.githubusercontent.com/assets/1617736/22222924/c07b2a1c-e16d-11e6-91b3-ac659550585c.png"  # noqa
 
 
+def get_words(body, my_username):
+    return list(chain.from_iterable(re.findall(r'\S+', x) for x in body.splitlines() if '@' + my_username in x))  # noqa
+
+
 def parse_commands(body, username, repo_cfg, state, my_username, db, states,
                    *, realtime=False, sha=''):
     global global_cfg
     state_changed = False
 
-    _reviewer_auth_verified = functools.partial(
-        verify_auth,
+    _reviewer_auth_verified = verify_auth(
         username,
         repo_cfg,
         state,
         AuthState.REVIEWER,
         realtime,
-        my_username,
+        my_username
     )
-    _try_auth_verified = functools.partial(
-        verify_auth,
+
+    _try_auth_verified = verify_auth(
         username,
         repo_cfg,
         state,
         AuthState.TRY,
         realtime,
-        my_username,
+        my_username
     )
 
-    words = list(chain.from_iterable(re.findall(r'\S+', x) for x in body.splitlines() if '@' + my_username in x))  # noqa
+    words = get_words(body, my_username)
     if words[1:] == ["are", "you", "still", "there?"] and realtime:
-        state.add_comment(
-            ":cake: {}\n\n![]({})".format(
-                random.choice(PORTAL_TURRET_DIALOG), PORTAL_TURRET_IMAGE)
-            )
+        still_here(state)
+
+    # reverse the list, as usually the review status
+    # is indicated at the end of the comment.
     for i, word in reversed(list(enumerate(words))):
         found = True
         if word == 'r+' or word.startswith('r='):
-            if not _reviewer_auth_verified():
+            if not _reviewer_auth_verified:
                 continue
 
-            if not sha and i + 1 < len(words):
-                cur_sha = sha_or_blank(words[i + 1])
-            else:
-                cur_sha = sha
-
-            approver = word[len('r='):] if word.startswith('r=') else username
-
-            # Ignore "r=me"
-            if approver == 'me':
+            if not review_approved(words, word, state, realtime,
+                                   username, my_username, sha, states):
                 continue
-
-            # Ignore WIP PRs
-            if any(map(state.title.startswith, [
-                'WIP', 'TODO', '[WIP]', '[TODO]',
-            ])):
-                if realtime:
-                    state.add_comment(':clipboard: Looks like this PR is still in progress, ignoring approval')  # noqa
-                continue
-
-            # Sometimes, GitHub sends the head SHA of a PR as 0000000
-            # through the webhook. This is called a "null commit", and
-            # seems to happen when GitHub internally encounters a race
-            # condition. Last time, it happened when squashing commits
-            # in a PR. In this case, we just try to retrieve the head
-            # SHA manually.
-            if all(x == '0' for x in state.head_sha):
-                if realtime:
-                    state.add_comment(
-                        ':bangbang: Invalid head SHA found, retrying: `{}`'
-                        .format(state.head_sha)
-                    )
-
-                state.head_sha = state.get_repo().pull_request(state.num).head.sha  # noqa
-                state.save()
-
-                assert any(x != '0' for x in state.head_sha)
-
-            if state.approved_by and realtime and username != my_username:
-                for _state in states[state.repo_label].values():
-                    if _state.status == 'pending':
-                        break
-                else:
-                    _state = None
-
-                lines = []
-
-                if state.status in ['failure', 'error']:
-                    lines.append('- This pull request previously failed. You should add more commits to fix the bug, or use `retry` to trigger a build again.')  # noqa
-
-                if _state:
-                    if state == _state:
-                        lines.append('- This pull request is currently being tested. If there\'s no response from the continuous integration service, you may use `retry` to trigger a build again.')  # noqa
-                    else:
-                        lines.append('- There\'s another pull request that is currently being tested, blocking this pull request: #{}'.format(_state.num))  # noqa
-
-                if lines:
-                    lines.insert(0, '')
-                lines.insert(0, ':bulb: This pull request was already approved, no need to approve it again.')  # noqa
-
-                state.add_comment('\n'.join(lines))
-
-            if sha_cmp(cur_sha, state.head_sha):
-                state.approved_by = approver
-                state.try_ = False
-                state.set_status('')
-
-                state.save()
-            elif realtime and username != my_username:
-                if cur_sha:
-                    msg = '`{}` is not a valid commit SHA.'.format(cur_sha)
-                    state.add_comment(
-                        ':scream_cat: {} Please try again with `{:.7}`.'
-                        .format(msg, state.head_sha)
-                    )
-                else:
-                    state.add_comment(
-                        ':pushpin: Commit {:.7} has been approved by `{}`\n\n<!-- @{} r={} {} -->'  # noqa
-                        .format(
-                            state.head_sha,
-                            approver,
-                            my_username,
-                            approver,
-                            state.head_sha,
-                    ))
-                    treeclosed = state.blocked_by_closed_tree()
-                    if treeclosed:
-                        state.add_comment(
-                            ':evergreen_tree: The tree is currently closed for pull requests below priority {}, this pull request will be tested once the tree is reopened'  # noqa
-                            .format(treeclosed)
-                        )
-                    state.change_labels(LabelEvent.APPROVED)
 
         elif word == 'r-':
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER,
-                               realtime, my_username):
+            if not _reviewer_auth_verified:
                 continue
-
-            state.approved_by = ''
-            state.save()
-            if realtime:
-                state.change_labels(LabelEvent.REJECTED)
+            review_rejected(state, realtime)
 
         elif word.startswith('p='):
-            if not verify_auth(username, repo_cfg, state, AuthState.TRY,
-                               realtime, my_username):
+            if not _try_auth_verified:
                 continue
-            try:
-                pvalue = int(word[len('p='):])
-            except ValueError:
+            if not set_priority(state, word[len('p='):], global_cfg):
                 continue
-
-            if pvalue > global_cfg['max_priority']:
-                if realtime:
-                    state.add_comment(
-                        ':stop_sign: Priority higher than {} is ignored.'
-                        .format(global_cfg['max_priority'])
-                    )
-                continue
-            state.priority = pvalue
-            state.save()
 
         elif word.startswith('delegate='):
-            if not verify_auth(username, repo_cfg, state, AuthState.REVIEWER,
-                               realtime, my_username):
+            if not _reviewer_auth_verified:
                 continue
-
-            state.delegate = word[len('delegate='):]
-            state.save()
-
-            if realtime:
-                state.add_comment(
-                    ':v: @{} can now approve this pull request'
-                    .format(state.delegate)
-                )
+            delegate_to(state, realtime, word[len('delegate='):])
 
         elif word == 'delegate-':
             # TODO: why is this a TRY?
-            if not _try_auth_verified():
+            if not _try_auth_verified:
                 continue
-            state.delegate = ''
-            state.save()
+            delegate_negative(state)
 
         elif word == 'delegate+':
-            if not _reviewer_auth_verified():
+            if not _reviewer_auth_verified:
                 continue
-
-            state.delegate = state.get_repo().pull_request(state.num).user.login  # noqa
-            state.save()
-
-            if realtime:
-                state.add_comment(
-                    ':v: @{} can now approve this pull request'
-                    .format(state.delegate)
-                )
+            delegate_positive(state, realtime)
 
         elif word == 'retry' and realtime:
             if not _try_auth_verified():
                 continue
-            state.set_status('')
-            if realtime:
-                event = LabelEvent.TRY if state.try_ else LabelEvent.APPROVED
-                state.change_labels(event)
+            retry(state)
 
         elif word in ['try', 'try-'] and realtime:
-            if not _try_auth_verified():
+            if not _try_auth_verified:
                 continue
-            state.try_ = word == 'try'
-
-            state.merge_sha = ''
-            state.init_build_res([])
-
-            state.save()
-            if realtime and state.try_:
-                # `try-` just resets the `try` bit and doesn't correspond to
-                # any meaningful labeling events.
-                state.change_labels(LabelEvent.TRY)
+            _try(state, word, realtime)
 
         elif word in ['rollup', 'rollup-']:
-            if not _try_auth_verified():
+            if not _try_auth_verified:
                 continue
-            state.rollup = word == 'rollup'
-
-            state.save()
+            rollup(state, word)
 
         elif word == 'force' and realtime:
-            if not _try_auth_verified():
+            if not _try_auth_verified:
                 continue
-            if 'buildbot' in repo_cfg:
-                with buildbot_sess(repo_cfg) as sess:
-                    res = sess.post(
-                        repo_cfg['buildbot']['url'] + '/builders/_selected/stopselected',   # noqa
-                        allow_redirects=False,
-                        data={
-                            'selected': repo_cfg['buildbot']['builders'],
-                            'comments': INTERRUPTED_BY_HOMU_FMT.format(int(time.time())),  # noqa
-                    })
-
-            if 'authzfail' in res.text:
-                err = 'Authorization failed'
-            else:
-                mat = re.search('(?s)<div class="error">(.*?)</div>', res.text)
-                if mat:
-                    err = mat.group(1).strip()
-                    if not err:
-                        err = 'Unknown error'
-                else:
-                    err = ''
-
-            if err:
-                state.add_comment(
-                    ':bomb: Buildbot returned an error: `{}`'.format(err)
-                )
+            force(repo_cfg, state)
 
         elif word == 'clean' and realtime:
-            if not _try_auth_verified():
+            if not _try_auth_verified:
                 continue
-            state.merge_sha = ''
-            state.init_build_res([])
+            clean(state)
 
-            state.save()
         elif (word == 'hello?' or word == 'ping') and realtime:
-            state.add_comment(":sleepy: I'm awake I'm awake")
+            hello_or_ping(state)
+
         elif word.startswith('treeclosed='):
-            if not _reviewer_auth_verified():
+            if not _reviewer_auth_verified:
                 continue
-            try:
-                treeclosed = int(word[len('treeclosed='):])
-                state.change_treeclosed(treeclosed)
-            except ValueError:
-                pass
-            state.save()
+            set_treeclosed(state, word)
+
         elif word == 'treeclosed-':
-            if not _reviewer_auth_verified():
+            if not _reviewer_auth_verified:
                 continue
-            state.change_treeclosed(-1)
-            state.save()
+            treeclosed_negative(state)
+
         elif 'hooks' in global_cfg:
+            # TODO: Can't extract this code to a new function
+            # because it changes the value of `found`.
             hook_found = False
             for hook in global_cfg['hooks']:
                 hook_cfg = global_cfg['hooks'][hook]
@@ -741,10 +579,236 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
 
         if found:
             state_changed = True
-
             words[i] = ''
 
     return state_changed
+
+
+def still_here(state):
+    state.add_comment(
+        ":cake: {}\n\n![]({})".format(
+            random.choice(PORTAL_TURRET_DIALOG), PORTAL_TURRET_IMAGE)
+        )
+
+
+def hello_or_ping(state):
+    state.add_comment(":sleepy: I'm awake I'm awake")
+
+
+def treeclosed_negative(state):
+    state.change_treeclosed(-1)
+    state.save()
+
+
+def set_treeclosed(state, word):
+    try:
+        treeclosed = int(word[len('treeclosed='):])
+        state.change_treeclosed(treeclosed)
+    except ValueError:
+        pass
+    state.save()
+
+
+def force(repo_cfg, state):
+    if 'buildbot' in repo_cfg:
+        with buildbot_sess(repo_cfg) as sess:
+            res = sess.post(
+                repo_cfg['buildbot']['url'] + '/builders/_selected/stopselected',   # noqa
+                allow_redirects=False,
+                data={
+                    'selected': repo_cfg['buildbot']['builders'],
+                    'comments': INTERRUPTED_BY_HOMU_FMT.format(int(time.time())),  # noqa
+            })
+    if 'authzfail' in res.text:
+        err = 'Authorization failed'
+    else:
+        mat = re.search('(?s)<div class="error">(.*?)</div>', res.text)
+        if mat:
+            err = mat.group(1).strip()
+            if not err:
+                err = 'Unknown error'
+        else:
+            err = ''
+    if err:
+        state.add_comment(
+            ':bomb: Buildbot returned an error: `{}`'.format(err)
+        )
+
+
+def rollup(state, word):
+    state.rollup = word == 'rollup'
+    state.save()
+
+
+def _try(state, word):
+    state.try_ = word == 'try'
+    state.merge_sha = ''
+    state.init_build_res([])
+    state.save()
+    if state.try_:
+        # `try-` just resets the `try` bit and doesn't correspond to
+        # any meaningful labeling events.
+        state.change_labels(LabelEvent.TRY)
+
+
+def clean(state):
+    state.merge_sha = ''
+    state.init_build_res([])
+    state.save()
+
+
+def retry(state):
+    state.set_status('')
+    event = LabelEvent.TRY if state.try_ else LabelEvent.APPROVED
+    state.change_labels(event)
+
+
+def delegate_negative(state):
+    state.delegate = ''
+    state.save()
+
+
+def delegate_positive(state, realtime):
+    state.delegate = state.get_repo().pull_request(state.num).user.login  # noqa
+    state.save()
+
+    if realtime:
+        state.add_comment(
+            ':v: @{} can now approve this pull request'
+            .format(state.delegate)
+        )
+
+
+def delegate_to(state, realtime, delegate):
+    state.delegate = delegate
+    state.save()
+
+    if realtime:
+        state.add_comment(
+            ':v: @{} can now approve this pull request'
+            .format(state.delegate)
+        )
+
+
+def set_priority(state, realtime, priority, global_cfg):
+    try:
+        pvalue = int(priority)
+    except ValueError:
+        return False
+
+    if pvalue > global_cfg['max_priority']:
+        if realtime:
+            state.add_comment(
+                ':stop_sign: Priority higher than {} is ignored.'
+                .format(global_cfg['max_priority'])
+            )
+        return False
+    state.priority = pvalue
+    state.save()
+    return True
+
+
+def review_approved(words, word, state, realtime, username,
+                    my_username, i, sha, states):
+    if not sha and i + 1 < len(words):
+        cur_sha = sha_or_blank(words[i + 1])
+    else:
+        cur_sha = sha
+
+    approver = word[len('r='):] if word.startswith('r=') else username
+
+    # Ignore "r=me"
+    if approver == 'me':
+        return False
+
+    # Ignore WIP PRs
+    if any(map(state.title.startswith, [
+        'WIP', 'TODO', '[WIP]', '[TODO]',
+    ])):
+        if realtime:
+            state.add_comment(':clipboard: Looks like this PR is still in progress, ignoring approval')  # noqa
+        return False
+
+    # Sometimes, GitHub sends the head SHA of a PR as 0000000
+    # through the webhook. This is called a "null commit", and
+    # seems to happen when GitHub internally encounters a race
+    # condition. Last time, it happened when squashing commits
+    # in a PR. In this case, we just try to retrieve the head
+    # SHA manually.
+    if all(x == '0' for x in state.head_sha):
+        if realtime:
+            state.add_comment(
+                ':bangbang: Invalid head SHA found, retrying: `{}`'
+                .format(state.head_sha)
+            )
+
+        state.head_sha = state.get_repo().pull_request(state.num).head.sha  # noqa
+        state.save()
+
+        assert any(x != '0' for x in state.head_sha)
+
+    if state.approved_by and realtime and username != my_username:
+        for _state in states[state.repo_label].values():
+            if _state.status == 'pending':
+                break
+        else:
+            _state = None
+
+        lines = []
+
+        if state.status in ['failure', 'error']:
+            lines.append('- This pull request previously failed. You should add more commits to fix the bug, or use `retry` to trigger a build again.')  # noqa
+
+        if _state:
+            if state == _state:
+                lines.append('- This pull request is currently being tested. If there\'s no response from the continuous integration service, you may use `retry` to trigger a build again.')  # noqa
+            else:
+                lines.append('- There\'s another pull request that is currently being tested, blocking this pull request: #{}'.format(_state.num))  # noqa
+
+        if lines:
+            lines.insert(0, '')
+        lines.insert(0, ':bulb: This pull request was already approved, no need to approve it again.')  # noqa
+
+        state.add_comment('\n'.join(lines))
+
+    if sha_cmp(cur_sha, state.head_sha):
+        state.approved_by = approver
+        state.try_ = False
+        state.set_status('')
+
+        state.save()
+    elif realtime and username != my_username:
+        if cur_sha:
+            msg = '`{}` is not a valid commit SHA.'.format(cur_sha)
+            state.add_comment(
+                ':scream_cat: {} Please try again with `{:.7}`.'
+                .format(msg, state.head_sha)
+            )
+        else:
+            state.add_comment(
+                ':pushpin: Commit {:.7} has been approved by `{}`\n\n<!-- @{} r={} {} -->'  # noqa
+                .format(
+                    state.head_sha,
+                    approver,
+                    my_username,
+                    approver,
+                    state.head_sha,
+            ))
+            treeclosed = state.blocked_by_closed_tree()
+            if treeclosed:
+                state.add_comment(
+                    ':evergreen_tree: The tree is currently closed for pull requests below priority {}, this pull request will be tested once the tree is reopened'  # noqa
+                    .format(treeclosed)
+                )
+            state.change_labels(LabelEvent.APPROVED)
+    return True
+
+
+def review_rejected(state, realtime):
+    state.approved_by = ''
+    state.save()
+    if realtime:
+        state.change_labels(LabelEvent.REJECTED)
 
 
 def handle_hook_response(state, hook_cfg, body, extra_data):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
 
     packages=['homu'],
     install_requires=[
-        'github3.py',
+        'github3.py<1.0',
         'toml',
         'Jinja2',
         'requests',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,265 @@
+import unittest
+from unittest.mock import patch, Mock, MagicMock, call
+from homu.main import LabelEvent
+from homu.main import get_words, still_here, hello_or_ping, \
+treeclosed_negative, sha_or_blank, sha_cmp, set_treeclosed, \
+clean, retry, delegate_negative, delegate_positive, delegate_to, \
+rollup, _try, set_priority, review_rejected, review_approved, force
+
+class TestMain(unittest.TestCase):
+
+    def test_get_words_no_username(self):
+        self.assertEqual(get_words("Hi, I'm a test message.", ''), [])
+
+    def test_get_words_incorrect_username(self):
+        self.assertEqual(get_words("@user I'm a message", 'username'), [])
+
+    def test_get_words_correct_username(self):
+        self.assertEqual(get_words("@user I'm a message", 'user'), ['@user', "I'm", 'a', 'message'])
+
+    @patch('homu.main.PullReqState')
+    def test_still_here(self, MockPullReqState):
+        state = MockPullReqState()
+        still_here(state)
+        state.add_comment.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_hello_or_ping(self, MockPullReqState):
+        state = MockPullReqState()
+        hello_or_ping(state)
+        state.add_comment.assert_called_once_with(":sleepy: I'm awake I'm awake")
+
+    @patch('homu.main.PullReqState')
+    def test_treeclosed_negative(self, MockPullReqState):
+        state = MockPullReqState()
+        treeclosed_negative(state)
+        state.change_treeclosed.assert_called_once_with(-1)
+        state.save.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_treeclosed_negative(self, MockPullReqState):
+        state = MockPullReqState()
+        set_treeclosed(state, 'treeclosed=123')
+        state.change_treeclosed.assert_called_once_with(123)
+        state.save.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_rollup_positive(self, MockPullReqState):
+        state = MockPullReqState()
+        rollup(state, 'rollup')
+        self.assertTrue(state.rollup)
+        state.save.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_rollup_negative(self, MockPullReqState):
+        state = MockPullReqState()
+        rollup(state, 'rollup-')
+        self.assertFalse(state.rollup)
+        state.save.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_try_positive(self, MockPullReqState):
+        state = MockPullReqState()
+        _try(state, 'try')
+        self.assertTrue(state.try_)
+        state.init_build_res.assert_called_once_with([])
+        state.save.assert_called_once()
+        state.change_labels.assert_called_once_with(LabelEvent.TRY)
+
+    @patch('homu.main.PullReqState')
+    def test_try_negative(self, MockPullReqState):
+        state = MockPullReqState()
+        _try(state, 'try-')
+        self.assertFalse(state.try_)
+        state.init_build_res.assert_called_once_with([])
+        state.save.assert_called_once()
+        assert not state.change_labels.called, 'change_labels was called and should never be.'
+
+    @patch('homu.main.PullReqState')
+    def test_clean(self, MockPullReqState):
+        state = MockPullReqState()
+        clean(state)
+        self.assertEqual(state.merge_sha, '')
+        state.init_build_res.assert_called_once_with([])
+        state.save.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_retry_try(self, MockPullReqState):
+        state = MockPullReqState()
+        state.try_ = True
+        retry(state)
+        state.set_status.assert_called_once_with('')
+        state.change_labels.assert_called_once_with(LabelEvent.TRY)
+
+    @patch('homu.main.PullReqState')
+    def test_retry_approved(self, MockPullReqState):
+        state = MockPullReqState()
+        state.try_ = False
+        retry(state)
+        state.set_status.assert_called_once_with('')
+        state.change_labels.assert_called_once_with(LabelEvent.APPROVED)
+
+    @patch('homu.main.PullReqState')
+    def test_delegate_negative(self, MockPullReqState):
+        state = MockPullReqState()
+        delegate_negative(state)
+        self.assertEqual(state.delegate, '')
+        state.save.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_delegate_positive(self, MockPullReqState):
+        state = MockPullReqState()
+        delegate_positive(state, True)
+        state.get_repo.assert_called_once()
+        state.add_comment.assert_called_once()
+        state.save.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_delegate_to(self, MockPullReqState):
+        state = MockPullReqState()
+        delegate_to(state, True, 'user')
+        self.assertEqual(state.delegate, 'user')
+        state.save.assert_called_once()
+        state.add_comment.assert_called_once_with(
+            ':v: @user can now approve this pull request'
+        )
+
+    @patch('homu.main.PullReqState')
+    def test_set_priority_not_priority_less_than_max_priority(self, MockPullReqState):
+        state = MockPullReqState()
+        set_priority(state, True, '1', {'max_priority': 3})
+        self.assertEqual(state.priority, 1)
+        state.save.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_set_priority_not_priority_more_than_max_priority(self, MockPullReqState):
+        state = MockPullReqState()
+        set_priority(state, True, '5', {'max_priority': 3})
+        state.add_comment.assert_called_once_with(':stop_sign: Priority higher than 3 is ignored.')
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_approver_me(self, MockPullReqState):
+        state = MockPullReqState()
+        self.assertFalse(review_approved(['r=me', 'approved'], 'r=me', state, True, 'user', 'user', 0, '', []))
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_wip(self, MockPullReqState):
+        state = MockPullReqState()
+        state.title = 'WIP work in progress'
+        self.assertFalse(review_approved(['r+', 'approved'], 'r+', state, True, 'user', 'user', 0, '', []))
+        state.add_comment.assert_called_once_with(':clipboard: Looks like this PR is still in progress, ignoring approval')
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_todo(self, MockPullReqState):
+        state = MockPullReqState()
+        state.title = 'TODO work in progress'
+        self.assertFalse(review_approved(['r+', 'approved'], 'r+', state, True, 'user', 'user', 0, '', []))
+        state.add_comment.assert_called_once_with(':clipboard: Looks like this PR is still in progress, ignoring approval')
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_equal_usernames(self, MockPullReqState):
+        state = MockPullReqState()
+        state.head_sha = 'abcd123'
+        state.title = "My pull request"
+        self.assertTrue(review_approved(['r+', 'approved'], 'r+', state, True, 'user', 'user', 0, 'abcd123', []))
+        self.assertEqual(state.approved_by, 'user')
+        self.assertFalse(state.try_)
+        state.set_status.assert_called_once_with('')
+        state.save.assert_called_once()
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_different_usernames_sha_equals_head_sha(self, MockPullReqState):
+        state = MockPullReqState()
+        state.head_sha = 'abcd123'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(review_approved(['r+', 'approved'], 'r+', state, True, 'user1', 'user2', 0, 'abcd123', states))
+        self.assertEqual(state.approved_by, 'user1')
+        self.assertFalse(state.try_)
+        state.set_status.assert_called_once_with('')
+        state.save.assert_called_once()
+        state.add_comment.assert_called_once_with(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again.")
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_different_usernames_sha_different_head_sha(self, MockPullReqState):
+        state = MockPullReqState()
+        state.head_sha = 'sdf456'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        state.num = 1
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(review_approved(['r+', 'approved'], 'r+', state, True, 'user1', 'user2', 0, 'abcd123', states))
+        state.add_comment.assert_has_calls([call(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again."),
+                                            call(':scream_cat: `abcd123` is not a valid commit SHA. Please try again with `sdf456`.')])
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_different_usernames_blank_sha_not_blocked_by_closed_tree(self, MockPullReqState):
+        state = MockPullReqState()
+        state.blocked_by_closed_tree.return_value = 0
+        state.head_sha = 'sdf456'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(review_approved(['r+', 'approved'], 'r+', state, True, 'user1', 'user2', 0, '', states))
+        state.add_comment.assert_has_calls([call(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again."),
+                                            call(':pushpin: Commit sdf456 has been approved by `user1`\n\n<!-- @user2 r=user1 sdf456 -->')])
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_different_usernames_blank_sha_blocked_by_closed_tree(self, MockPullReqState):
+        state = MockPullReqState()
+        state.blocked_by_closed_tree.return_value = 1
+        state.head_sha = 'sdf456'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(review_approved(['r+', 'approved'], 'r+', state, True, 'user1', 'user2', 0, '', states))
+        state.add_comment.assert_has_calls([call(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again."),
+                                            call(':pushpin: Commit sdf456 has been approved by `user1`\n\n<!-- @user2 r=user1 sdf456 -->'),
+                                            call(':evergreen_tree: The tree is currently closed for pull requests below priority 1, this pull request will be tested once the tree is reopened')])
+        state.change_labels.assert_called_once_with(LabelEvent.APPROVED)
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_same_usernames_sha_different_head_sha(self, MockPullReqState):
+        state = MockPullReqState()
+        state.head_sha = 'sdf456'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(review_approved(['r+', 'approved'], 'r+', state, True, 'user', 'user', 0, 'abcd123', states))
+
+    @patch('homu.main.PullReqState')
+    def test_review_rejected(self, MockPullReqState):
+        state = MockPullReqState()
+        review_rejected(state, True)
+        self.assertEqual(state.approved_by, '')
+        state.save.assert_called_once()
+        state.change_labels.assert_called_once_with(LabelEvent.REJECTED)
+
+    def test_sha_or_blank_return_sha(self):
+        self.assertEqual(sha_or_blank('f5d42200481'), 'f5d42200481')
+
+    def test_sha_or_blank_return_blank(self):
+        self.assertEqual(sha_or_blank('f5d@12'), '')
+
+    def test_sha_cmp_equal(self):
+        self.assertTrue(sha_cmp('f259660', 'f259660b128ae59133dff123998ee9b643aff050'))
+
+    def test_sha_cmp_not_equal(self):
+        self.assertFalse(sha_cmp('aaabbb12', 'f259660b128ae59133dff123998ee9b643aff050'))
+
+    def test_sha_cmp_short_lenght(self):
+        self.assertFalse(sha_cmp('f25', 'f259660b128ae59133dff123998ee9b643aff050'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR address https://github.com/servo/homu/issues/143. This is a first step in making Homu testable.

A small refactor has been done, extracting the logic in `parse_commands` to its own functions, to be able to mock the state and add tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/149)
<!-- Reviewable:end -->
