### PR TITLE
Refactor parse_commands to add tests.

### DIFF
--- a/homu/action.py
+++ b/homu/action.py
@@ -1,0 +1,210 @@
+import random
+from enum import Enum
+
+
+class LabelEvent(Enum):
+    APPROVED = 'approved'
+    REJECTED = 'rejected'
+    CONFLICT = 'conflict'
+    SUCCEED = 'succeed'
+    FAILED = 'failed'
+    TRY = 'try'
+    TRY_SUCCEED = 'try_succeed'
+    TRY_FAILED = 'try_failed'
+    EXEMPTED = 'exempted'
+    TIMED_OUT = 'timed_out'
+    INTERRUPTED = 'interrupted'
+    PUSHED = 'pushed'
+
+
+PORTAL_TURRET_DIALOG = ["Target acquired", "Activated", "There you are"]
+PORTAL_TURRET_IMAGE = "https://cloud.githubusercontent.com/assets/1617736/22222924/c07b2a1c-e16d-11e6-91b3-ac659550585c.png" # noqa
+
+
+class Action:
+    def get_portal_turret_dialog(self):
+        return random.choice(PORTAL_TURRET_DIALOG)
+
+    def still_here(self, state):
+        state.add_comment(
+            ":cake: {}\n\n![]({})".format(
+                self.get_portal_turret_dialog(), PORTAL_TURRET_IMAGE)
+            )
+
+    def delegate_to(self, state, realtime, delegate):
+        state.delegate = delegate
+        state.save()
+
+        if realtime:
+            state.add_comment(
+                ':v: @{} can now approve this pull request'
+                .format(state.delegate)
+            )
+
+    def set_treeclosed(self, state, word):
+        try:
+            treeclosed = int(word[len('treeclosed='):])
+            state.change_treeclosed(treeclosed)
+        except ValueError:
+            pass
+        state.save()
+
+    def treeclosed_negative(self, state):
+        state.change_treeclosed(-1)
+        state.save()
+
+    def hello_or_ping(self, state):
+        state.add_comment(":sleepy: I'm awake I'm awake")
+
+    def rollup(self, state, word):
+        state.rollup = word == 'rollup'
+        state.save()
+
+    def _try(self, state, word):
+        state.try_ = word == 'try'
+        state.merge_sha = ''
+        state.init_build_res([])
+        state.save()
+        if state.try_:
+            # `try-` just resets the `try` bit and doesn't correspond to
+            # any meaningful labeling events.
+            state.change_labels(LabelEvent.TRY)
+
+    def clean(self, state):
+        state.merge_sha = ''
+        state.init_build_res([])
+        state.save()
+
+    def retry(self, state):
+        state.set_status('')
+        event = LabelEvent.TRY if state.try_ else LabelEvent.APPROVED
+        state.change_labels(event)
+
+    def delegate_negative(self, state):
+        state.delegate = ''
+        state.save()
+
+    def review_rejected(self, state, realtime):
+        state.approved_by = ''
+        state.save()
+        if realtime:
+            state.change_labels(LabelEvent.REJECTED)
+
+    def delegate_positive(self, state, delegate, realtime):
+        state.delegate = delegate
+        state.save()
+
+        if realtime:
+            state.add_comment(
+                ':v: @{} can now approve this pull request'
+                .format(state.delegate)
+            )
+
+    def set_priority(self, state, realtime, priority, cfg):
+        try:
+            pvalue = int(priority)
+        except ValueError:
+            return False
+
+        if pvalue > cfg['max_priority']:
+            if realtime:
+                state.add_comment(
+                    ':stop_sign: Priority higher than {} is ignored.'
+                    .format(cfg['max_priority'])
+                )
+            return False
+        state.priority = pvalue
+        state.save()
+        return True
+
+    def review_approved(self, state, realtime, approver, username,
+                        my_username, sha, states):
+        # Ignore "r=me"
+        if approver == 'me':
+            return False
+
+        # Ignore WIP PRs
+        if any(map(state.title.startswith, [
+            'WIP', 'TODO', '[WIP]', '[TODO]',
+        ])):
+            if realtime:
+                state.add_comment(':clipboard: Looks like this PR is still in progress, ignoring approval')  # noqa
+            return False
+
+        # Sometimes, GitHub sends the head SHA of a PR as 0000000
+        # through the webhook. This is called a "null commit", and
+        # seems to happen when GitHub internally encounters a race
+        # condition. Last time, it happened when squashing commits
+        # in a PR. In this case, we just try to retrieve the head
+        # SHA manually.
+        if all(x == '0' for x in state.head_sha):
+            if realtime:
+                state.add_comment(
+                    ':bangbang: Invalid head SHA found, retrying: `{}`'
+                    .format(state.head_sha)
+                )
+
+            state.head_sha = state.get_repo().pull_request(state.num).head.sha  # noqa
+            state.save()
+
+            assert any(x != '0' for x in state.head_sha)
+
+        if state.approved_by and realtime and username != my_username:
+            for _state in states[state.repo_label].values():
+                if _state.status == 'pending':
+                    break
+            else:
+                _state = None
+
+            lines = []
+
+            if state.status in ['failure', 'error']:
+                lines.append('- This pull request previously failed. You should add more commits to fix the bug, or use `retry` to trigger a build again.')  # noqa
+
+            if _state:
+                if state == _state:
+                    lines.append('- This pull request is currently being tested. If there\'s no response from the continuous integration service, you may use `retry` to trigger a build again.')  # noqa
+                else:
+                    lines.append('- There\'s another pull request that is currently being tested, blocking this pull request: #{}'.format(_state.num))  # noqa
+
+            if lines:
+                lines.insert(0, '')
+            lines.insert(0, ':bulb: This pull request was already approved, no need to approve it again.')  # noqa
+
+            state.add_comment('\n'.join(lines))
+
+        if Action.sha_cmp(sha, state.head_sha):
+            state.approved_by = approver
+            state.try_ = False
+            state.set_status('')
+
+            state.save()
+        elif realtime and username != my_username:
+            if sha:
+                msg = '`{}` is not a valid commit SHA.'.format(sha)
+                state.add_comment(
+                    ':scream_cat: {} Please try again with `{:.7}`.'
+                    .format(msg, state.head_sha)
+                )
+            else:
+                state.add_comment(
+                    ':pushpin: Commit {:.7} has been approved by `{}`\n\n<!-- @{} r={} {} -->'  # noqa
+                    .format(
+                        state.head_sha,
+                        approver,
+                        my_username,
+                        approver,
+                        state.head_sha,
+                ))
+                treeclosed = state.blocked_by_closed_tree()
+                if treeclosed:
+                    state.add_comment(
+                        ':evergreen_tree: The tree is currently closed for pull requests below priority {}, this pull request will be tested once the tree is reopened'  # noqa
+                        .format(treeclosed)
+                    )
+                state.change_labels(LabelEvent.APPROVED)
+        return True
+
+    @staticmethod
+    def sha_cmp(short, full):
+        return len(short) >= 4 and short == full[:len(short)]

--- a/homu/action.py
+++ b/homu/action.py
@@ -21,190 +21,202 @@ PORTAL_TURRET_DIALOG = ["Target acquired", "Activated", "There you are"]
 PORTAL_TURRET_IMAGE = "https://cloud.githubusercontent.com/assets/1617736/22222924/c07b2a1c-e16d-11e6-91b3-ac659550585c.png" # noqa
 
 
-class Action:
-    def get_portal_turret_dialog(self):
-        return random.choice(PORTAL_TURRET_DIALOG)
+def get_portal_turret_dialog():
+    return random.choice(PORTAL_TURRET_DIALOG)
 
-    def still_here(self, state):
+
+def still_here(state):
+    state.add_comment(
+        ":cake: {}\n\n![]({})".format(
+            get_portal_turret_dialog(), PORTAL_TURRET_IMAGE)
+        )
+
+
+def delegate_to(state, realtime, delegate):
+    state.delegate = delegate
+    state.save()
+    if realtime:
         state.add_comment(
-            ":cake: {}\n\n![]({})".format(
-                self.get_portal_turret_dialog(), PORTAL_TURRET_IMAGE)
-            )
+            ':v: @{} can now approve this pull request'
+            .format(state.delegate)
+        )
 
-    def delegate_to(self, state, realtime, delegate):
-        state.delegate = delegate
-        state.save()
 
+def set_treeclosed(state, word):
+    try:
+        treeclosed = int(word[len('treeclosed='):])
+        state.change_treeclosed(treeclosed)
+    except ValueError:
+        pass
+    state.save()
+
+
+def treeclosed_negative(state):
+    state.change_treeclosed(-1)
+    state.save()
+
+
+def hello_or_ping(state):
+    state.add_comment(":sleepy: I'm awake I'm awake")
+
+
+def rollup(state, word):
+    state.rollup = word == 'rollup'
+    state.save()
+
+
+def _try(state, word):
+    state.try_ = word == 'try'
+    state.merge_sha = ''
+    state.init_build_res([])
+    state.save()
+    if state.try_:
+        # `try-` just resets the `try` bit and doesn't correspond to
+        # any meaningful labeling events.
+        state.change_labels(LabelEvent.TRY)
+
+
+def clean(state):
+    state.merge_sha = ''
+    state.init_build_res([])
+    state.save()
+
+
+def retry(state):
+    state.set_status('')
+    event = LabelEvent.TRY if state.try_ else LabelEvent.APPROVED
+    state.change_labels(event)
+
+
+def delegate_negative(state):
+    state.delegate = ''
+    state.save()
+
+
+def review_rejected(state, realtime):
+    state.approved_by = ''
+    state.save()
+    if realtime:
+        state.change_labels(LabelEvent.REJECTED)
+
+
+def delegate_positive(state, delegate, realtime):
+    state.delegate = delegate
+    state.save()
+
+    if realtime:
+        state.add_comment(
+            ':v: @{} can now approve this pull request'
+            .format(state.delegate)
+        )
+
+
+def set_priority(state, realtime, priority, cfg):
+    try:
+        pvalue = int(priority)
+    except ValueError:
+        return False
+
+    if pvalue > cfg['max_priority']:
         if realtime:
             state.add_comment(
-                ':v: @{} can now approve this pull request'
-                .format(state.delegate)
+                ':stop_sign: Priority higher than {} is ignored.'
+                .format(cfg['max_priority'])
+            )
+        return False
+    state.priority = pvalue
+    state.save()
+    return True
+
+
+def review_approved(state, realtime, approver, username,
+                    my_username, sha, states):
+    # Ignore "r=me"
+    if approver == 'me':
+        return False
+
+    # Ignore WIP PRs
+    if any(map(state.title.startswith, [
+        'WIP', 'TODO', '[WIP]', '[TODO]',
+    ])):
+        if realtime:
+            state.add_comment(':clipboard: Looks like this PR is still in progress, ignoring approval')  # noqa
+        return False
+
+    # Sometimes, GitHub sends the head SHA of a PR as 0000000
+    # through the webhook. This is called a "null commit", and
+    # seems to happen when GitHub internally encounters a race
+    # condition. Last time, it happened when squashing commits
+    # in a PR. In this case, we just try to retrieve the head
+    # SHA manually.
+    if all(x == '0' for x in state.head_sha):
+        if realtime:
+            state.add_comment(
+                ':bangbang: Invalid head SHA found, retrying: `{}`'
+                .format(state.head_sha)
             )
 
-    def set_treeclosed(self, state, word):
-        try:
-            treeclosed = int(word[len('treeclosed='):])
-            state.change_treeclosed(treeclosed)
-        except ValueError:
-            pass
+        state.head_sha = state.get_repo().pull_request(state.num).head.sha  # noqa
         state.save()
 
-    def treeclosed_negative(self, state):
-        state.change_treeclosed(-1)
-        state.save()
+        assert any(x != '0' for x in state.head_sha)
 
-    def hello_or_ping(self, state):
-        state.add_comment(":sleepy: I'm awake I'm awake")
+    if state.approved_by and realtime and username != my_username:
+        for _state in states[state.repo_label].values():
+            if _state.status == 'pending':
+                break
+        else:
+            _state = None
 
-    def rollup(self, state, word):
-        state.rollup = word == 'rollup'
-        state.save()
+        lines = []
 
-    def _try(self, state, word):
-        state.try_ = word == 'try'
-        state.merge_sha = ''
-        state.init_build_res([])
-        state.save()
-        if state.try_:
-            # `try-` just resets the `try` bit and doesn't correspond to
-            # any meaningful labeling events.
-            state.change_labels(LabelEvent.TRY)
+        if state.status in ['failure', 'error']:
+            lines.append('- This pull request previously failed. You should add more commits to fix the bug, or use `retry` to trigger a build again.')  # noqa
 
-    def clean(self, state):
-        state.merge_sha = ''
-        state.init_build_res([])
-        state.save()
+        if _state:
+            if state == _state:
+                lines.append('- This pull request is currently being tested. If there\'s no response from the continuous integration service, you may use `retry` to trigger a build again.')  # noqa
+            else:
+                lines.append('- There\'s another pull request that is currently being tested, blocking this pull request: #{}'.format(_state.num))  # noqa
 
-    def retry(self, state):
+        if lines:
+            lines.insert(0, '')
+        lines.insert(0, ':bulb: This pull request was already approved, no need to approve it again.')  # noqa
+
+        state.add_comment('\n'.join(lines))
+
+    if sha_cmp(sha, state.head_sha):
+        state.approved_by = approver
+        state.try_ = False
         state.set_status('')
-        event = LabelEvent.TRY if state.try_ else LabelEvent.APPROVED
-        state.change_labels(event)
 
-    def delegate_negative(self, state):
-        state.delegate = ''
         state.save()
-
-    def review_rejected(self, state, realtime):
-        state.approved_by = ''
-        state.save()
-        if realtime:
-            state.change_labels(LabelEvent.REJECTED)
-
-    def delegate_positive(self, state, delegate, realtime):
-        state.delegate = delegate
-        state.save()
-
-        if realtime:
+    elif realtime and username != my_username:
+        if sha:
+            msg = '`{}` is not a valid commit SHA.'.format(sha)
             state.add_comment(
-                ':v: @{} can now approve this pull request'
-                .format(state.delegate)
+                ':scream_cat: {} Please try again with `{:.7}`.'
+                .format(msg, state.head_sha)
             )
-
-    def set_priority(self, state, realtime, priority, cfg):
-        try:
-            pvalue = int(priority)
-        except ValueError:
-            return False
-
-        if pvalue > cfg['max_priority']:
-            if realtime:
+        else:
+            state.add_comment(
+                ':pushpin: Commit {:.7} has been approved by `{}`\n\n<!-- @{} r={} {} -->'  # noqa
+                .format(
+                    state.head_sha,
+                    approver,
+                    my_username,
+                    approver,
+                    state.head_sha,
+            ))
+            treeclosed = state.blocked_by_closed_tree()
+            if treeclosed:
                 state.add_comment(
-                    ':stop_sign: Priority higher than {} is ignored.'
-                    .format(cfg['max_priority'])
+                    ':evergreen_tree: The tree is currently closed for pull requests below priority {}, this pull request will be tested once the tree is reopened'  # noqa
+                    .format(treeclosed)
                 )
-            return False
-        state.priority = pvalue
-        state.save()
-        return True
+            state.change_labels(LabelEvent.APPROVED)
+    return True
 
-    def review_approved(self, state, realtime, approver, username,
-                        my_username, sha, states):
-        # Ignore "r=me"
-        if approver == 'me':
-            return False
 
-        # Ignore WIP PRs
-        if any(map(state.title.startswith, [
-            'WIP', 'TODO', '[WIP]', '[TODO]',
-        ])):
-            if realtime:
-                state.add_comment(':clipboard: Looks like this PR is still in progress, ignoring approval')  # noqa
-            return False
-
-        # Sometimes, GitHub sends the head SHA of a PR as 0000000
-        # through the webhook. This is called a "null commit", and
-        # seems to happen when GitHub internally encounters a race
-        # condition. Last time, it happened when squashing commits
-        # in a PR. In this case, we just try to retrieve the head
-        # SHA manually.
-        if all(x == '0' for x in state.head_sha):
-            if realtime:
-                state.add_comment(
-                    ':bangbang: Invalid head SHA found, retrying: `{}`'
-                    .format(state.head_sha)
-                )
-
-            state.head_sha = state.get_repo().pull_request(state.num).head.sha  # noqa
-            state.save()
-
-            assert any(x != '0' for x in state.head_sha)
-
-        if state.approved_by and realtime and username != my_username:
-            for _state in states[state.repo_label].values():
-                if _state.status == 'pending':
-                    break
-            else:
-                _state = None
-
-            lines = []
-
-            if state.status in ['failure', 'error']:
-                lines.append('- This pull request previously failed. You should add more commits to fix the bug, or use `retry` to trigger a build again.')  # noqa
-
-            if _state:
-                if state == _state:
-                    lines.append('- This pull request is currently being tested. If there\'s no response from the continuous integration service, you may use `retry` to trigger a build again.')  # noqa
-                else:
-                    lines.append('- There\'s another pull request that is currently being tested, blocking this pull request: #{}'.format(_state.num))  # noqa
-
-            if lines:
-                lines.insert(0, '')
-            lines.insert(0, ':bulb: This pull request was already approved, no need to approve it again.')  # noqa
-
-            state.add_comment('\n'.join(lines))
-
-        if Action.sha_cmp(sha, state.head_sha):
-            state.approved_by = approver
-            state.try_ = False
-            state.set_status('')
-
-            state.save()
-        elif realtime and username != my_username:
-            if sha:
-                msg = '`{}` is not a valid commit SHA.'.format(sha)
-                state.add_comment(
-                    ':scream_cat: {} Please try again with `{:.7}`.'
-                    .format(msg, state.head_sha)
-                )
-            else:
-                state.add_comment(
-                    ':pushpin: Commit {:.7} has been approved by `{}`\n\n<!-- @{} r={} {} -->'  # noqa
-                    .format(
-                        state.head_sha,
-                        approver,
-                        my_username,
-                        approver,
-                        state.head_sha,
-                ))
-                treeclosed = state.blocked_by_closed_tree()
-                if treeclosed:
-                    state.add_comment(
-                        ':evergreen_tree: The tree is currently closed for pull requests below priority {}, this pull request will be tested once the tree is reopened'  # noqa
-                        .format(treeclosed)
-                    )
-                state.change_labels(LabelEvent.APPROVED)
-        return True
-
-    @staticmethod
-    def sha_cmp(short, full):
-        return len(short) >= 4 and short == full[:len(short)]
+def sha_cmp(short, full):
+    return len(short) >= 4 and short == full[:len(short)]

--- a/homu/main.py
+++ b/homu/main.py
@@ -7,7 +7,7 @@ import functools
 from enum import IntEnum
 from . import utils
 from .utils import lazy_debug
-from .action import Action, LabelEvent
+from . import action
 import logging
 from threading import Thread, Lock, Timer
 import time
@@ -368,7 +368,7 @@ class PullReqState:
             desc,
             context='homu')
         self.add_comment(':boom: {}'.format(desc))
-        self.change_labels(LabelEvent.TIMED_OUT)
+        self.change_labels(action.LabelEvent.TIMED_OUT)
 
 
 def sha_or_blank(sha):
@@ -442,8 +442,6 @@ def parse_commands(cfg, body, username, repo_cfg, state, my_username, db,
         realtime,
         my_username,
     )
-
-    action = Action()
 
     words = get_words(body, my_username)
     if words[1:] == ["are", "you", "still", "there?"] and realtime:
@@ -816,7 +814,7 @@ def create_merge(state, repo_cfg, branch, logger, git_cfg,
         context='homu')
 
     state.add_comment(':lock: ' + desc)
-    state.change_labels(LabelEvent.CONFLICT)
+    state.change_labels(action.LabelEvent.CONFLICT)
 
     return ''
 
@@ -872,7 +870,7 @@ def do_exemption_merge(state, logger, repo_cfg, git_cfg, url, check_merge,
     utils.github_create_status(state.get_repo(), state.head_sha, 'success',
                                url, desc, context='homu')
     state.add_comment(':zap: {}: {}.'.format(desc, reason))
-    state.change_labels(LabelEvent.EXEMPTED)
+    state.change_labels(action.LabelEvent.EXEMPTED)
 
     state.merge_sha = merge_sha
     state.save()
@@ -1237,7 +1235,7 @@ def fetch_mergeability(mergeable_que):
                 state.add_comment(':umbrella: The latest upstream changes{} made this pull request unmergeable. Please resolve the merge conflicts.'.format(  # noqa
                     _blame
                 ))
-                state.change_labels(LabelEvent.CONFLICT)
+                state.change_labels(action.LabelEvent.CONFLICT)
 
             state.set_mergeable(mergeable, que=False)
 

--- a/homu/server.py
+++ b/homu/server.py
@@ -7,8 +7,8 @@ from .main import (
     db_query,
     INTERRUPTED_BY_HOMU_RE,
     synchronize,
-    LabelEvent,
 )
+from .action import LabelEvent
 from . import utils
 from .utils import lazy_debug
 import github3
@@ -690,7 +690,7 @@ def synch(user_gh, state, repo_label, repo_cfg, repo):
     if not repo.is_collaborator(user_gh.user().login):
         abort(400, 'You are not a collaborator')
 
-    Thread(target=synchronize, args=[repo_label, repo_cfg, g.logger,
+    Thread(target=synchronize, args=[repo_label, g.cfg, repo_cfg, g.logger,
                                      g.gh, g.states, g.repos, g.db,
                                      g.mergeable_que, g.my_username,
                                      g.repo_labels]).start()
@@ -702,8 +702,8 @@ def synch_all():
     @retry(wait_exponential_multiplier=1000, wait_exponential_max=600000)
     def sync_repo(repo_label, g):
         try:
-            synchronize(repo_label, g.repo_cfgs[repo_label], g.logger, g.gh,
-                        g.states, g.repos, g.db, g.mergeable_que,
+            synchronize(repo_label, g.cfg, g.repo_cfgs[repo_label], g.logger,
+                        g.gh, g.states, g.repos, g.db, g.mergeable_que,
                         g.my_username, g.repo_labels)
         except Exception:
             print('* Error while synchronizing {}'.format(repo_label))
@@ -729,7 +729,7 @@ def admin():
         g.repo_cfgs[repo_label] = repo_cfg
         g.repo_labels[repo_cfg['owner'], repo_cfg['name']] = repo_label
 
-        Thread(target=synchronize, args=[repo_label, repo_cfg, g.logger,
+        Thread(target=synchronize, args=[repo_label, g.cfg, repo_cfg, g.logger,
                                          g.gh, g.states, g.repos, g.db,
                                          g.mergeable_que, g.my_username,
                                          g.repo_labels]).start()

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,29 +1,28 @@
 import unittest
 from unittest.mock import patch, call
-from homu.action import Action
-from homu.main import LabelEvent
+from homu import action
+from homu.action import LabelEvent
 
 class TestAction(unittest.TestCase):
 
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.get_portal_turret_dialog', return_value='message')
+    @patch('homu.action.get_portal_turret_dialog', return_value='message')
     def test_still_here(self, mock_message, MockPullReqState):
         state = MockPullReqState()
-        cmd = Action()
-        cmd.still_here(state)
+        action.still_here(state)
         state.add_comment.assert_called_once_with(':cake: message\n\n![](https://cloud.githubusercontent.com/assets/1617736/22222924/c07b2a1c-e16d-11e6-91b3-ac659550585c.png)')
 
     @patch('homu.main.PullReqState')
     def test_set_treeclosed(self, MockPullReqState):
         state = MockPullReqState()
-        Action().set_treeclosed(state, 'treeclosed=123')
+        action.set_treeclosed(state, 'treeclosed=123')
         state.change_treeclosed.assert_called_once_with(123)
         state.save.assert_called_once_with()
 
     @patch('homu.main.PullReqState')
     def test_delegate_to(self, MockPullReqState):
         state = MockPullReqState()
-        Action().delegate_to(state, True, 'user')
+        action.delegate_to(state, True, 'user')
         self.assertEqual(state.delegate, 'user')
         state.save.assert_called_once_with()
         state.add_comment.assert_called_once_with(
@@ -33,27 +32,27 @@ class TestAction(unittest.TestCase):
     @patch('homu.main.PullReqState')
     def test_hello_or_ping(self, MockPullReqState):
         state = MockPullReqState()
-        Action().hello_or_ping(state)
+        action.hello_or_ping(state)
         state.add_comment.assert_called_once_with(":sleepy: I'm awake I'm awake")
 
     @patch('homu.main.PullReqState')
     def test_rollup_positive(self, MockPullReqState):
         state = MockPullReqState()
-        Action().rollup(state, 'rollup')
+        action.rollup(state, 'rollup')
         self.assertTrue(state.rollup)
         state.save.assert_called_once_with()
 
     @patch('homu.main.PullReqState')
     def test_rollup_negative(self, MockPullReqState):
         state = MockPullReqState()
-        Action().rollup(state, 'rollup-')
+        action.rollup(state, 'rollup-')
         self.assertFalse(state.rollup)
         state.save.assert_called_once_with()
 
     @patch('homu.main.PullReqState')
     def test_try_positive(self, MockPullReqState):
         state = MockPullReqState()
-        Action()._try(state, 'try')
+        action._try(state, 'try')
         self.assertTrue(state.try_)
         state.init_build_res.assert_called_once_with([])
         state.save.assert_called_once_with()
@@ -62,7 +61,7 @@ class TestAction(unittest.TestCase):
     @patch('homu.main.PullReqState')
     def test_try_negative(self, MockPullReqState):
         state = MockPullReqState()
-        Action()._try(state, 'try-')
+        action._try(state, 'try-')
         self.assertFalse(state.try_)
         state.init_build_res.assert_called_once_with([])
         state.save.assert_called_once_with()
@@ -71,7 +70,7 @@ class TestAction(unittest.TestCase):
     @patch('homu.main.PullReqState')
     def test_clean(self, MockPullReqState):
         state = MockPullReqState()
-        Action().clean(state)
+        action.clean(state)
         self.assertEqual(state.merge_sha, '')
         state.init_build_res.assert_called_once_with([])
         state.save.assert_called_once_with()
@@ -80,14 +79,14 @@ class TestAction(unittest.TestCase):
     def test_retry_try(self, MockPullReqState):
         state = MockPullReqState()
         state.try_ = True
-        Action().retry(state)
+        action.retry(state)
         state.set_status.assert_called_once_with('')
         state.change_labels.assert_called_once_with(LabelEvent.TRY)
 
     @patch('homu.main.PullReqState')
     def test_treeclosed_negative(self, MockPullReqState):
         state = MockPullReqState()
-        Action().treeclosed_negative(state)
+        action.treeclosed_negative(state)
         state.change_treeclosed.assert_called_once_with(-1)
         state.save.assert_called_once_with()
 
@@ -95,7 +94,7 @@ class TestAction(unittest.TestCase):
     def test_retry_approved(self, MockPullReqState):
         state = MockPullReqState()
         state.try_ = False
-        Action().retry(state)
+        action.retry(state)
         state.set_status.assert_called_once_with('')
         state.change_labels.assert_called_once_with(LabelEvent.APPROVED)
 
@@ -103,14 +102,14 @@ class TestAction(unittest.TestCase):
     def test_delegate_negative(self, MockPullReqState):
         state = MockPullReqState()
         state.delegate = 'delegate'
-        Action().delegate_negative(state)
+        action.delegate_negative(state)
         self.assertEqual(state.delegate, '')
         state.save.assert_called_once_with()
 
     @patch('homu.main.PullReqState')
     def test_delegate_positive_realtime(self, MockPullReqState):
         state = MockPullReqState()
-        Action().delegate_positive(state, 'delegate', True)
+        action.delegate_positive(state, 'delegate', True)
         self.assertEqual(state.delegate, 'delegate')
         state.add_comment.assert_called_once_with(':v: @delegate can now approve this pull request')
         state.save.assert_called_once_with()
@@ -118,7 +117,7 @@ class TestAction(unittest.TestCase):
     @patch('homu.main.PullReqState')
     def test_delegate_positive_not_realtime(self, MockPullReqState):
         state = MockPullReqState()
-        Action().delegate_positive(state, 'delegate', False)
+        action.delegate_positive(state, 'delegate', False)
         self.assertEqual(state.delegate, 'delegate')
         state.save.assert_called_once_with()
         assert not state.add_comment.called, 'state.save was called and should never be.'
@@ -126,7 +125,7 @@ class TestAction(unittest.TestCase):
     @patch('homu.main.PullReqState')
     def test_set_priority_not_priority_less_than_max_priority(self, MockPullReqState):
         state = MockPullReqState()
-        Action().set_priority(state, True, '1', {'max_priority': 3})
+        action.set_priority(state, True, '1', {'max_priority': 3})
         self.assertEqual(state.priority, 1)
         state.save.assert_called_once_with()
 
@@ -134,7 +133,7 @@ class TestAction(unittest.TestCase):
     def test_set_priority_not_priority_more_than_max_priority(self, MockPullReqState):
         state = MockPullReqState()
         state.priority = 2
-        self.assertFalse(Action().set_priority(state, True, '5', {'max_priority': 3}))
+        self.assertFalse(action.set_priority(state, True, '5', {'max_priority': 3}))
         self.assertEqual(state.priority, 2)
         state.add_comment.assert_called_once_with(':stop_sign: Priority higher than 3 is ignored.')
         assert not state.save.called, 'state.save was called and should never be.'
@@ -142,20 +141,20 @@ class TestAction(unittest.TestCase):
     @patch('homu.main.PullReqState')
     def test_review_approved_approver_me(self, MockPullReqState):
         state = MockPullReqState()
-        self.assertFalse(Action().review_approved(state, True, 'me', 'user', 'user', '', []))
+        self.assertFalse(action.review_approved(state, True, 'me', 'user', 'user', '', []))
 
     @patch('homu.main.PullReqState')
     def test_review_approved_wip_todo_realtime(self, MockPullReqState):
         state = MockPullReqState()
         state.title = 'WIP work in progress'
-        self.assertFalse(Action().review_approved(state, True, 'user', 'user', 'user', '', []))
+        self.assertFalse(action.review_approved(state, True, 'user', 'user', 'user', '', []))
         state.add_comment.assert_called_once_with(':clipboard: Looks like this PR is still in progress, ignoring approval')
 
     @patch('homu.main.PullReqState')
     def test_review_approved_wip_not_realtime(self, MockPullReqState):
         state = MockPullReqState()
         state.title = 'WIP work in progress'
-        self.assertFalse(Action().review_approved(state, False, 'user', 'user', 'user', '', []))
+        self.assertFalse(action.review_approved(state, False, 'user', 'user', 'user', '', []))
         assert not state.add_comment.called, 'state.add_comment was called and should never be.'
 
     @patch('homu.main.PullReqState')
@@ -163,7 +162,7 @@ class TestAction(unittest.TestCase):
         state = MockPullReqState()
         state.head_sha = 'abcd123'
         state.title = "My pull request"
-        self.assertTrue(Action().review_approved(state, True, 'user' ,'user', 'user', 'abcd123', []))
+        self.assertTrue(action.review_approved(state, True, 'user' ,'user', 'user', 'abcd123', []))
         self.assertEqual(state.approved_by, 'user')
         self.assertFalse(state.try_)
         state.set_status.assert_called_once_with('')
@@ -178,7 +177,7 @@ class TestAction(unittest.TestCase):
         state.status = 'pending'
         states = {}
         states[state.repo_label] = {'label': state}
-        self.assertTrue(Action().review_approved(state, True, 'user1' ,'user1', 'user2', 'abcd123', states))
+        self.assertTrue(action.review_approved(state, True, 'user1' ,'user1', 'user2', 'abcd123', states))
         self.assertEqual(state.approved_by, 'user1')
         self.assertFalse(state.try_)
         state.set_status.assert_called_once_with('')
@@ -195,7 +194,7 @@ class TestAction(unittest.TestCase):
         state.num = 1
         states = {}
         states[state.repo_label] = {'label': state}
-        self.assertTrue(Action().review_approved(state, True, 'user1', 'user1', 'user2', 'abcd123', states))
+        self.assertTrue(action.review_approved(state, True, 'user1', 'user1', 'user2', 'abcd123', states))
         state.add_comment.assert_has_calls([call(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again."),
                                             call(':scream_cat: `abcd123` is not a valid commit SHA. Please try again with `sdf456`.')])
 
@@ -209,7 +208,7 @@ class TestAction(unittest.TestCase):
         state.status = 'pending'
         states = {}
         states[state.repo_label] = {'label': state}
-        self.assertTrue(Action().review_approved(state, True, 'user1', 'user1', 'user2', '', states))
+        self.assertTrue(action.review_approved(state, True, 'user1', 'user1', 'user2', '', states))
         state.add_comment.assert_has_calls([call(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again."),
                                             call(':pushpin: Commit sdf456 has been approved by `user1`\n\n<!-- @user2 r=user1 sdf456 -->')])
 
@@ -223,7 +222,7 @@ class TestAction(unittest.TestCase):
         state.status = 'pending'
         states = {}
         states[state.repo_label] = {'label': state}
-        self.assertTrue(Action().review_approved(state, True, 'user1', 'user1', 'user2', '', states))
+        self.assertTrue(action.review_approved(state, True, 'user1', 'user1', 'user2', '', states))
         state.add_comment.assert_has_calls([call(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again."),
                                             call(':pushpin: Commit sdf456 has been approved by `user1`\n\n<!-- @user2 r=user1 sdf456 -->'),
                                             call(':evergreen_tree: The tree is currently closed for pull requests below priority 1, this pull request will be tested once the tree is reopened')])
@@ -238,24 +237,24 @@ class TestAction(unittest.TestCase):
         state.status = 'pending'
         states = {}
         states[state.repo_label] = {'label': state}
-        self.assertTrue(Action().review_approved(state, True, 'user', 'user', 'user', 'abcd123', states))
+        self.assertTrue(action.review_approved(state, True, 'user', 'user', 'user', 'abcd123', states))
 
     @patch('homu.main.PullReqState')
     def test_review_rejected(self, MockPullReqState):
         state = MockPullReqState()
-        Action().review_rejected(state, True)
+        action.review_rejected(state, True)
         self.assertEqual(state.approved_by, '')
         state.save.assert_called_once_with()
         state.change_labels.assert_called_once_with(LabelEvent.REJECTED)
 
     def test_sha_cmp_equal(self):
-        self.assertTrue(Action.sha_cmp('f259660', 'f259660b128ae59133dff123998ee9b643aff050'))
+        self.assertTrue(action.sha_cmp('f259660', 'f259660b128ae59133dff123998ee9b643aff050'))
 
     def test_sha_cmp_not_equal(self):
-        self.assertFalse(Action.sha_cmp('aaabbb12', 'f259660b128ae59133dff123998ee9b643aff050'))
+        self.assertFalse(action.sha_cmp('aaabbb12', 'f259660b128ae59133dff123998ee9b643aff050'))
 
     def test_sha_cmp_short_length(self):
-        self.assertFalse(Action.sha_cmp('f25', 'f259660b128ae59133dff123998ee9b643aff050'))
+        self.assertFalse(action.sha_cmp('f25', 'f259660b128ae59133dff123998ee9b643aff050'))
 
 
 if __name__ == '__main__':

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,0 +1,262 @@
+import unittest
+from unittest.mock import patch, call
+from homu.action import Action
+from homu.main import LabelEvent
+
+class TestAction(unittest.TestCase):
+
+    @patch('homu.main.PullReqState')
+    @patch('homu.action.Action.get_portal_turret_dialog', return_value='message')
+    def test_still_here(self, mock_message, MockPullReqState):
+        state = MockPullReqState()
+        cmd = Action()
+        cmd.still_here(state)
+        state.add_comment.assert_called_once_with(':cake: message\n\n![](https://cloud.githubusercontent.com/assets/1617736/22222924/c07b2a1c-e16d-11e6-91b3-ac659550585c.png)')
+
+    @patch('homu.main.PullReqState')
+    def test_set_treeclosed(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().set_treeclosed(state, 'treeclosed=123')
+        state.change_treeclosed.assert_called_once_with(123)
+        state.save.assert_called_once_with()
+
+    @patch('homu.main.PullReqState')
+    def test_delegate_to(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().delegate_to(state, True, 'user')
+        self.assertEqual(state.delegate, 'user')
+        state.save.assert_called_once_with()
+        state.add_comment.assert_called_once_with(
+            ':v: @user can now approve this pull request'
+        )
+
+    @patch('homu.main.PullReqState')
+    def test_hello_or_ping(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().hello_or_ping(state)
+        state.add_comment.assert_called_once_with(":sleepy: I'm awake I'm awake")
+
+    @patch('homu.main.PullReqState')
+    def test_rollup_positive(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().rollup(state, 'rollup')
+        self.assertTrue(state.rollup)
+        state.save.assert_called_once_with()
+
+    @patch('homu.main.PullReqState')
+    def test_rollup_negative(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().rollup(state, 'rollup-')
+        self.assertFalse(state.rollup)
+        state.save.assert_called_once_with()
+
+    @patch('homu.main.PullReqState')
+    def test_try_positive(self, MockPullReqState):
+        state = MockPullReqState()
+        Action()._try(state, 'try')
+        self.assertTrue(state.try_)
+        state.init_build_res.assert_called_once_with([])
+        state.save.assert_called_once_with()
+        state.change_labels.assert_called_once_with(LabelEvent.TRY)
+
+    @patch('homu.main.PullReqState')
+    def test_try_negative(self, MockPullReqState):
+        state = MockPullReqState()
+        Action()._try(state, 'try-')
+        self.assertFalse(state.try_)
+        state.init_build_res.assert_called_once_with([])
+        state.save.assert_called_once_with()
+        assert not state.change_labels.called, 'change_labels was called and should never be.'
+
+    @patch('homu.main.PullReqState')
+    def test_clean(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().clean(state)
+        self.assertEqual(state.merge_sha, '')
+        state.init_build_res.assert_called_once_with([])
+        state.save.assert_called_once_with()
+
+    @patch('homu.main.PullReqState')
+    def test_retry_try(self, MockPullReqState):
+        state = MockPullReqState()
+        state.try_ = True
+        Action().retry(state)
+        state.set_status.assert_called_once_with('')
+        state.change_labels.assert_called_once_with(LabelEvent.TRY)
+
+    @patch('homu.main.PullReqState')
+    def test_treeclosed_negative(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().treeclosed_negative(state)
+        state.change_treeclosed.assert_called_once_with(-1)
+        state.save.assert_called_once_with()
+
+    @patch('homu.main.PullReqState')
+    def test_retry_approved(self, MockPullReqState):
+        state = MockPullReqState()
+        state.try_ = False
+        Action().retry(state)
+        state.set_status.assert_called_once_with('')
+        state.change_labels.assert_called_once_with(LabelEvent.APPROVED)
+
+    @patch('homu.main.PullReqState')
+    def test_delegate_negative(self, MockPullReqState):
+        state = MockPullReqState()
+        state.delegate = 'delegate'
+        Action().delegate_negative(state)
+        self.assertEqual(state.delegate, '')
+        state.save.assert_called_once_with()
+
+    @patch('homu.main.PullReqState')
+    def test_delegate_positive_realtime(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().delegate_positive(state, 'delegate', True)
+        self.assertEqual(state.delegate, 'delegate')
+        state.add_comment.assert_called_once_with(':v: @delegate can now approve this pull request')
+        state.save.assert_called_once_with()
+
+    @patch('homu.main.PullReqState')
+    def test_delegate_positive_not_realtime(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().delegate_positive(state, 'delegate', False)
+        self.assertEqual(state.delegate, 'delegate')
+        state.save.assert_called_once_with()
+        assert not state.add_comment.called, 'state.save was called and should never be.'
+
+    @patch('homu.main.PullReqState')
+    def test_set_priority_not_priority_less_than_max_priority(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().set_priority(state, True, '1', {'max_priority': 3})
+        self.assertEqual(state.priority, 1)
+        state.save.assert_called_once_with()
+
+    @patch('homu.main.PullReqState')
+    def test_set_priority_not_priority_more_than_max_priority(self, MockPullReqState):
+        state = MockPullReqState()
+        state.priority = 2
+        self.assertFalse(Action().set_priority(state, True, '5', {'max_priority': 3}))
+        self.assertEqual(state.priority, 2)
+        state.add_comment.assert_called_once_with(':stop_sign: Priority higher than 3 is ignored.')
+        assert not state.save.called, 'state.save was called and should never be.'
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_approver_me(self, MockPullReqState):
+        state = MockPullReqState()
+        self.assertFalse(Action().review_approved(state, True, 'me', 'user', 'user', '', []))
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_wip_todo_realtime(self, MockPullReqState):
+        state = MockPullReqState()
+        state.title = 'WIP work in progress'
+        self.assertFalse(Action().review_approved(state, True, 'user', 'user', 'user', '', []))
+        state.add_comment.assert_called_once_with(':clipboard: Looks like this PR is still in progress, ignoring approval')
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_wip_not_realtime(self, MockPullReqState):
+        state = MockPullReqState()
+        state.title = 'WIP work in progress'
+        self.assertFalse(Action().review_approved(state, False, 'user', 'user', 'user', '', []))
+        assert not state.add_comment.called, 'state.add_comment was called and should never be.'
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_equal_usernames(self, MockPullReqState):
+        state = MockPullReqState()
+        state.head_sha = 'abcd123'
+        state.title = "My pull request"
+        self.assertTrue(Action().review_approved(state, True, 'user' ,'user', 'user', 'abcd123', []))
+        self.assertEqual(state.approved_by, 'user')
+        self.assertFalse(state.try_)
+        state.set_status.assert_called_once_with('')
+        state.save.assert_called_once_with()
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_different_usernames_sha_equals_head_sha(self, MockPullReqState):
+        state = MockPullReqState()
+        state.head_sha = 'abcd123'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(Action().review_approved(state, True, 'user1' ,'user1', 'user2', 'abcd123', states))
+        self.assertEqual(state.approved_by, 'user1')
+        self.assertFalse(state.try_)
+        state.set_status.assert_called_once_with('')
+        state.save.assert_called_once_with()
+        state.add_comment.assert_called_once_with(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again.")
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_different_usernames_sha_different_head_sha(self, MockPullReqState):
+        state = MockPullReqState()
+        state.head_sha = 'sdf456'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        state.num = 1
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(Action().review_approved(state, True, 'user1', 'user1', 'user2', 'abcd123', states))
+        state.add_comment.assert_has_calls([call(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again."),
+                                            call(':scream_cat: `abcd123` is not a valid commit SHA. Please try again with `sdf456`.')])
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_different_usernames_blank_sha_not_blocked_by_closed_tree(self, MockPullReqState):
+        state = MockPullReqState()
+        state.blocked_by_closed_tree.return_value = 0
+        state.head_sha = 'sdf456'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(Action().review_approved(state, True, 'user1', 'user1', 'user2', '', states))
+        state.add_comment.assert_has_calls([call(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again."),
+                                            call(':pushpin: Commit sdf456 has been approved by `user1`\n\n<!-- @user2 r=user1 sdf456 -->')])
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_different_usernames_blank_sha_blocked_by_closed_tree(self, MockPullReqState):
+        state = MockPullReqState()
+        state.blocked_by_closed_tree.return_value = 1
+        state.head_sha = 'sdf456'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(Action().review_approved(state, True, 'user1', 'user1', 'user2', '', states))
+        state.add_comment.assert_has_calls([call(":bulb: This pull request was already approved, no need to approve it again.\n\n- This pull request is currently being tested. If there's no response from the continuous integration service, you may use `retry` to trigger a build again."),
+                                            call(':pushpin: Commit sdf456 has been approved by `user1`\n\n<!-- @user2 r=user1 sdf456 -->'),
+                                            call(':evergreen_tree: The tree is currently closed for pull requests below priority 1, this pull request will be tested once the tree is reopened')])
+        state.change_labels.assert_called_once_with(LabelEvent.APPROVED)
+
+    @patch('homu.main.PullReqState')
+    def test_review_approved_same_usernames_sha_different_head_sha(self, MockPullReqState):
+        state = MockPullReqState()
+        state.head_sha = 'sdf456'
+        state.title = "My pull request"
+        state.repo_label = 'label'
+        state.status = 'pending'
+        states = {}
+        states[state.repo_label] = {'label': state}
+        self.assertTrue(Action().review_approved(state, True, 'user', 'user', 'user', 'abcd123', states))
+
+    @patch('homu.main.PullReqState')
+    def test_review_rejected(self, MockPullReqState):
+        state = MockPullReqState()
+        Action().review_rejected(state, True)
+        self.assertEqual(state.approved_by, '')
+        state.save.assert_called_once_with()
+        state.change_labels.assert_called_once_with(LabelEvent.REJECTED)
+
+    def test_sha_cmp_equal(self):
+        self.assertTrue(Action.sha_cmp('f259660', 'f259660b128ae59133dff123998ee9b643aff050'))
+
+    def test_sha_cmp_not_equal(self):
+        self.assertFalse(Action.sha_cmp('aaabbb12', 'f259660b128ae59133dff123998ee9b643aff050'))
+
+    def test_sha_cmp_short_lenght(self):
+        self.assertFalse(Action.sha_cmp('f25', 'f259660b128ae59133dff123998ee9b643aff050'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -254,7 +254,7 @@ class TestAction(unittest.TestCase):
     def test_sha_cmp_not_equal(self):
         self.assertFalse(Action.sha_cmp('aaabbb12', 'f259660b128ae59133dff123998ee9b643aff050'))
 
-    def test_sha_cmp_short_lenght(self):
+    def test_sha_cmp_short_length(self):
         self.assertFalse(Action.sha_cmp('f25', 'f259660b128ae59133dff123998ee9b643aff050'))
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,7 +41,7 @@ class TestMain(unittest.TestCase):
         assert not mock_still_here.called, 'still_here was called and should never be.'
 
 
-    @patch('homu.main.get_words', return_value=["approved", "r+"])
+    @patch('homu.main.get_words', return_value=["r+"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
     @patch('homu.action.Action.review_approved')
@@ -50,7 +50,7 @@ class TestMain(unittest.TestCase):
         self.assertTrue(parse_commands({}, '', 'user', {}, state, 'my_user', '', [], sha='abc123'))
         mock_review_approved.assert_called_once_with(state, False, 'user', 'user', 'my_user', 'abc123', [])
 
-    @patch('homu.main.get_words', return_value=["approved", "r+"])
+    @patch('homu.main.get_words', return_value=["r+"])
     @patch('homu.main.verify_auth', return_value=False)
     @patch('homu.main.PullReqState')
     @patch('homu.action.Action.review_approved')
@@ -59,7 +59,7 @@ class TestMain(unittest.TestCase):
         self.assertFalse(parse_commands({}, '', 'user', {}, state, 'my_user', '', [], sha='abc123'))
         assert not mock_review_approved.called, 'mock_review_approved was called and should never be.'
 
-    @patch('homu.main.get_words', return_value=["approved", "r=user2"])
+    @patch('homu.main.get_words', return_value=["r=user2"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
     @patch('homu.action.Action.review_approved')
@@ -68,7 +68,7 @@ class TestMain(unittest.TestCase):
         self.assertTrue(parse_commands({}, '', 'user', {}, state, 'my_user', '', [], sha='abc123'))
         mock_review_approved.assert_called_once_with(state, False, 'user2', 'user', 'my_user', 'abc123', [])
 
-    @patch('homu.main.get_words', return_value=["nope", "r-"])
+    @patch('homu.main.get_words', return_value=["r-"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
     @patch('homu.action.Action.review_rejected')
@@ -77,7 +77,7 @@ class TestMain(unittest.TestCase):
         self.assertTrue(parse_commands({}, '', 'user', {}, state, 'my_user', '', [], sha='abc123'))
         mock_review_rejected.assert_called_once_with(state, False)
 
-    @patch('homu.main.get_words', return_value=["priority", "p=1"])
+    @patch('homu.main.get_words', return_value=["p=1"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
     @patch('homu.action.Action.set_priority')
@@ -86,7 +86,7 @@ class TestMain(unittest.TestCase):
         self.assertTrue(parse_commands({}, '', 'user', {}, state, 'my_user', '', [], sha='abc123'))
         mock_set_priority.assert_called_once_with(state, False, '1', {})
 
-    @patch('homu.main.get_words', return_value=["priority", "delegate=user2"])
+    @patch('homu.main.get_words', return_value=["delegate=user2"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
     @patch('homu.action.Action.delegate_to')
@@ -95,7 +95,7 @@ class TestMain(unittest.TestCase):
         self.assertTrue(parse_commands({}, '', 'user', {}, state, 'my_user', '', [], sha='abc123'))
         mock_delegate_to.assert_called_once_with(state, False, 'user2')
 
-    @patch('homu.main.get_words', return_value=["delegate negative", "delegate-"])
+    @patch('homu.main.get_words', return_value=["delegate-"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
     @patch('homu.action.Action.delegate_negative')
@@ -104,7 +104,7 @@ class TestMain(unittest.TestCase):
         self.assertTrue(parse_commands({}, '', 'user', {}, state, 'my_user', '', [], sha='abc123'))
         mock_delegate_negative.assert_called_once_with(state)
 
-    @patch('homu.main.get_words', return_value=["delegate positive", "delegate+"])
+    @patch('homu.main.get_words', return_value=["delegate+"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
     @patch('homu.action.Action.delegate_positive')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import patch, Mock, MagicMock, call
-from homu.main import LabelEvent
 from homu.main import sha_or_blank, force, parse_commands, \
 get_words
 
@@ -30,7 +29,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["@bot", "are", "you", "still", "there?"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.still_here')
+    @patch('homu.action.still_here')
     def test_parse_commands_still_here_realtime(self, mock_still_here, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertFalse(self.call_parse_commands(state=state, realtime=True))
@@ -40,7 +39,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["@bot", "are", "you", "still", "there?"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.still_here')
+    @patch('homu.action.still_here')
     def test_parse_commands_still_here_not_realtime(self, mock_still_here, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertFalse(self.call_parse_commands(state=state))
@@ -50,7 +49,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["r+"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.review_approved')
+    @patch('homu.action.review_approved')
     def test_parse_commands_review_approved_verified(self, mock_review_approved, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, sha='abc123'))
@@ -59,7 +58,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["r+"])
     @patch('homu.main.verify_auth', return_value=False)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.review_approved')
+    @patch('homu.action.review_approved')
     def test_parse_commands_review_approved_not_verified(self, mock_review_approved, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertFalse(self.call_parse_commands(state=state, sha='abc123'))
@@ -68,7 +67,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["r=user2"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.review_approved')
+    @patch('homu.action.review_approved')
     def test_parse_commands_review_approved_verified_different_approver(self, mock_review_approved, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, sha='abc123'))
@@ -77,7 +76,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["r-"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.review_rejected')
+    @patch('homu.action.review_rejected')
     def test_parse_commands_review_rejected(self, mock_review_rejected, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, sha='abc123'))
@@ -86,7 +85,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["p=1"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.set_priority')
+    @patch('homu.action.set_priority')
     def test_parse_commands_set_priority(self, mock_set_priority, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, sha='abc123'))
@@ -95,7 +94,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["delegate=user2"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.delegate_to')
+    @patch('homu.action.delegate_to')
     def test_parse_commands_delegate_to(self, mock_delegate_to, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, sha='abc123'))
@@ -104,7 +103,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["delegate-"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.delegate_negative')
+    @patch('homu.action.delegate_negative')
     def test_parse_commands_delegate_negative(self, mock_delegate_negative, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, sha='abc123'))
@@ -113,7 +112,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["delegate+"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.delegate_positive')
+    @patch('homu.action.delegate_positive')
     def test_parse_commands_delegate_positive(self, mock_delegate_positive, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         state.num = 2
@@ -124,7 +123,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["retry"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.retry')
+    @patch('homu.action.retry')
     def test_parse_commands_retry_realtime(self, mock_retry, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, realtime=True, sha='abc123'))
@@ -133,7 +132,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["retry"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.retry')
+    @patch('homu.action.retry')
     def test_parse_commands_retry_not_realtime(self, mock_retry, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertFalse(self.call_parse_commands(state=state, sha='abc123'))
@@ -142,7 +141,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["try"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action._try')
+    @patch('homu.action._try')
     def test_parse_commands_try_realtime(self, mock_try, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, realtime=True, sha='abc123'))
@@ -151,7 +150,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["try"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action._try')
+    @patch('homu.action._try')
     def test_parse_commands_try_not_realtime(self, mock_try, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertFalse(self.call_parse_commands(state=state, sha='abc123'))
@@ -160,7 +159,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["rollup"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.rollup')
+    @patch('homu.action.rollup')
     def test_parse_commands_rollup(self, mock_rollup, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, realtime=True, sha='abc123'))
@@ -169,7 +168,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["clean"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.clean')
+    @patch('homu.action.clean')
     def test_parse_commands_clean_realtime(self, mock_clean, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, realtime=True, sha='abc123'))
@@ -178,7 +177,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["clean"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.clean')
+    @patch('homu.action.clean')
     def test_parse_commands_clean_not_realtime(self, mock_clean, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertFalse(self.call_parse_commands(state=state, sha='abc123'))
@@ -187,7 +186,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["hello?"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.hello_or_ping')
+    @patch('homu.action.hello_or_ping')
     def test_parse_commands_hello_or_ping_realtime(self, mock_hello_or_ping, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, realtime=True, sha='abc123'))
@@ -196,7 +195,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["hello?"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.hello_or_ping')
+    @patch('homu.action.hello_or_ping')
     def test_parse_commands_hello_or_ping_not_realtime(self, mock_hello_or_ping, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertFalse(self.call_parse_commands(state=state, sha='abc123'))
@@ -205,7 +204,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["treeclosed=1"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.set_treeclosed')
+    @patch('homu.action.set_treeclosed')
     def test_parse_commands_set_treeclosed(self, mock_set_treeclosed, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, realtime=True, sha='abc123'))
@@ -214,7 +213,7 @@ class TestMain(unittest.TestCase):
     @patch('homu.main.get_words', return_value=["treeclosed-"])
     @patch('homu.main.verify_auth', return_value=True)
     @patch('homu.main.PullReqState')
-    @patch('homu.action.Action.treeclosed_negative')
+    @patch('homu.action.treeclosed_negative')
     def test_parse_commands_treeclosed_negative(self, mock_treeclosed_negative, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, realtime=True, sha='abc123'))


### PR DESCRIPTION
This PR tests `parse_commands` and extracts most of the actions (`force` and `hooks` can't be extracted yet) to a new class called `Actions`.
It also removes `global_cfg`. Now, `cfg` is passed to the server thread, and from there, is passed to the methods that require the configuration in `main.py`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/152)
<!-- Reviewable:end -->
