### PR TITLE
Add cfg to parse_commands calls in server.py

### DIFF
--- a/homu/server.py
+++ b/homu/server.py
@@ -300,6 +300,7 @@ def github():
                 state.body = info['pull_request']['body']
 
                 if parse_commands(
+                    g.cfg,
                     body,
                     username,
                     repo_cfg,
@@ -346,6 +347,7 @@ def github():
                 # FIXME: Review comments are ignored here
                 for c in state.get_repo().issue(pull_num).iter_comments():
                     found = parse_commands(
+                        g.cfg,
                         c.body,
                         c.user.login,
                         repo_cfg,
@@ -440,6 +442,7 @@ def github():
             state.body = info['issue']['body']
 
             if parse_commands(
+                g.cfg,
                 body,
                 username,
                 repo_cfg,


### PR DESCRIPTION
As reported in https://github.com/servo/homu/issues/154, some commands are failing because the configuration is not passed to `parse_commands` under certain conditions in `server.py`. This PR fixes this problem adding the missing parameter to those calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/155)
<!-- Reviewable:end -->
