### PR TITLE
Replaced slicing text from set_treeclosed method to its caller #153

### DIFF
--- a/homu/action.py
+++ b/homu/action.py
@@ -44,7 +44,7 @@ def delegate_to(state, realtime, delegate):
 
 def set_treeclosed(state, word):
     try:
-        treeclosed = int(word[len('treeclosed='):])
+        treeclosed = int(word)
         state.change_treeclosed(treeclosed)
     except ValueError:
         pass

--- a/homu/main.py
+++ b/homu/main.py
@@ -527,7 +527,7 @@ def parse_commands(cfg, body, username, repo_cfg, state, my_username, db,
         elif word.startswith('treeclosed='):
             if not _reviewer_auth_verified():
                 continue
-            action.set_treeclosed(state, word)
+            action.set_treeclosed(state, word.lstrip("treeclosed="))
 
         elif word == 'treeclosed-':
             if not _reviewer_auth_verified():

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -15,7 +15,7 @@ class TestAction(unittest.TestCase):
     @patch('homu.main.PullReqState')
     def test_set_treeclosed(self, MockPullReqState):
         state = MockPullReqState()
-        action.set_treeclosed(state, 'treeclosed=123')
+        action.set_treeclosed(state, '123')
         state.change_treeclosed.assert_called_once_with(123)
         state.save.assert_called_once_with()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -208,7 +208,7 @@ class TestMain(unittest.TestCase):
     def test_parse_commands_set_treeclosed(self, mock_set_treeclosed, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, realtime=True, sha='abc123'))
-        mock_set_treeclosed.assert_called_once_with(state, 'treeclosed=1')
+        mock_set_treeclosed.assert_called_once_with(state, '1')
 
     @patch('homu.main.get_words', return_value=["treeclosed-"])
     @patch('homu.main.verify_auth', return_value=True)


### PR DESCRIPTION
This pull request is for issue #153 

Replaced the slicing with strip by using `word.lstrip()`

The occurrences are been replaced up to my knowledge. @jdm let me know in case if I missed anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/158)
<!-- Reviewable:end -->
