### PR TITLE
pin github3.py version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
 
     packages=['homu'],
     install_requires=[
-        'github3.py<1.0',
+        'github3.py==0.9.6',
         'toml',
         'Jinja2',
         'requests',


### PR DESCRIPTION
1.0.0+ does not work the same way. We should eventually upgrade, but for
now, pinning the dependency.

For some reason the less-than syntax isn't enough.

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/164)
<!-- Reviewable:end -->
