### PR TITLE
Add support for try=chooser syntax

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -158,6 +158,9 @@ context = 'continuous-integration/travis-ci/push'
 #
 #
 ## Optional try choosers
+## If adding these, be sure to add associated
+## SingleBranchSchedulers for the try-CHOOSERNAME branch
+## in buildbot's master.cfg
 #[repo.NAME.buildbot.try_choosers]
 #mac = ["auto-mac-dev", "auto-mac-rel"]
 #wpt = ["linux-wpt1", "linux-wpt2"]

--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -155,7 +155,12 @@ context = 'continuous-integration/travis-ci/push'
 #
 #username = ""
 #password = ""
-
+#
+#
+## Optional try choosers
+#[repo.NAME.buildbot.try_choosers]
+#mac = ["auto-mac-dev", "auto-mac-rel"]
+#wpt = ["linux-wpt1", "linux-wpt2"]
 #
 ## Boolean which indicates whether the builder is included in try builds (defaults to true)
 #try = false

--- a/homu/main.py
+++ b/homu/main.py
@@ -1002,7 +1002,12 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
     repo_cfg = repo_cfgs[state.repo_label]
 
     builders = []
-    branch = 'try' if state.try_ else 'auto'
+    branch = 'auto'
+    if state.try_:
+        if state.try_choose:
+            branch = "try-%s" % state.try_choose
+        else:
+            branch = "try"
     branch = repo_cfg.get('branch', {}).get(branch, branch)
     can_try_travis_exemption = False
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -52,7 +52,7 @@ class TestAction(unittest.TestCase):
     @patch('homu.main.PullReqState')
     def test_try_positive(self, MockPullReqState):
         state = MockPullReqState()
-        action._try(state, 'try')
+        action._try(state, 'try', False, {})
         self.assertTrue(state.try_)
         state.init_build_res.assert_called_once_with([])
         state.save.assert_called_once_with()
@@ -61,7 +61,7 @@ class TestAction(unittest.TestCase):
     @patch('homu.main.PullReqState')
     def test_try_negative(self, MockPullReqState):
         state = MockPullReqState()
-        action._try(state, 'try-')
+        action._try(state, 'try-', False, {})
         self.assertFalse(state.try_)
         state.init_build_res.assert_called_once_with([])
         state.save.assert_called_once_with()

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,7 +1,20 @@
+from collections import OrderedDict
 import unittest
 from unittest.mock import patch, call
 from homu import action
 from homu.action import LabelEvent
+
+
+TRY_CHOOSER_CONFIG = {
+    "buildbot": {
+        "builders": ["mac-rel", "mac-wpt", "linux-wpt-1", "linux-wpt-2"],
+        # keeps the order for testing output
+        "try_choosers": OrderedDict([
+            ("mac", ["mac-rel", "mac-wpt"]),
+            ("wpt", ["linux-wpt-1", "linux-wpt-2"])
+        ])
+    }
+}
 
 class TestAction(unittest.TestCase):
 
@@ -66,6 +79,37 @@ class TestAction(unittest.TestCase):
         state.init_build_res.assert_called_once_with([])
         state.save.assert_called_once_with()
         assert not state.change_labels.called, 'change_labels was called and should never be.'
+
+    @patch('homu.main.PullReqState')
+    def test_try_chooser_no_setup(self, MockPullReqState):
+        state = MockPullReqState()
+        action._try(state, 'try', True, {}, choose="foo")
+        self.assertTrue(state.try_)
+        state.init_build_res.assert_called_once_with([])
+        state.save.assert_called_once_with()
+        state.change_labels.assert_called_once_with(LabelEvent.TRY)
+        state.add_comment.assert_called_once_with(":slightly_frowning_face: This repo does not have try choosers set up")
+
+    @patch('homu.main.PullReqState')
+    def test_try_chooser_not_found(self, MockPullReqState):
+        state = MockPullReqState()
+        action._try(state, 'try', True, TRY_CHOOSER_CONFIG, choose="foo")
+        self.assertTrue(state.try_)
+        self.assertEqual(state.try_choose, None)
+        state.init_build_res.assert_called_once_with([])
+        state.save.assert_called_once_with()
+        state.change_labels.assert_called_once_with(LabelEvent.TRY)
+        state.add_comment.assert_called_once_with(":slightly_frowning_face: There is no try chooser foo for this repo, try one of: mac, wpt")
+
+    @patch('homu.main.PullReqState')
+    def test_try_chooser_found(self, MockPullReqState):
+        state = MockPullReqState()
+        action._try(state, 'try', True, TRY_CHOOSER_CONFIG, choose="mac")
+        self.assertTrue(state.try_)
+        self.assertEqual(state.try_choose, "mac")
+        state.init_build_res.assert_called_once_with([])
+        state.save.assert_called_once_with()
+        state.change_labels.assert_called_once_with(LabelEvent.TRY)
 
     @patch('homu.main.PullReqState')
     def test_clean(self, MockPullReqState):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -145,7 +145,7 @@ class TestMain(unittest.TestCase):
     def test_parse_commands_try_realtime(self, mock_try, MockPullReqState, mock_auth, mock_words):
         state = MockPullReqState()
         self.assertTrue(self.call_parse_commands(state=state, realtime=True, sha='abc123'))
-        mock_try.assert_called_once_with(state, 'try')
+        mock_try.assert_called_once_with(state, 'try', True, {})
 
     @patch('homu.main.get_words', return_value=["try"])
     @patch('homu.main.verify_auth', return_value=True)


### PR DESCRIPTION
Adds support for try choosers in the configuration.

SQLite migration notes: Either start from a fresh db, or run `ALTER TABLE pull ADD try_choose text`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/167)
<!-- Reviewable:end -->
