### PR TITLE
Add support for build results page

### DIFF
--- a/homu/html/build_res.html
+++ b/homu/html/build_res.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Homu build result {{repo_label}}#{{pull}}</title>
+        <style>
+            * { font-family: sans-serif; }
+            h1 { font-size: 20px; }
+            h2 { font-size: 16px; }
+            p { font-size: 15px; }
+
+            table { border-collapse: collapse; }
+            td, th { border: 2px solid white; padding: 5px; font-size: 13px; }
+            tr:nth-child(even) { background: #ddd; }
+
+            .treeclosed { color: grey }
+            .success { background-color: #80C0F0; }
+            .failed { background-color: #F08080; }
+            .pending { background-color: #F0DE57; }
+
+            .yes { color: green; }
+            .no { color: red; }
+
+            .sorting_asc:after { content: " ▲"; }
+            .sorting_desc:after { content: " ▼"; }
+            .dataTables_filter, .dataTables_info, .dataTables_empty { display: none; }
+            #search { width: 150px; }
+            .hide { display: none; }
+            th { cursor: pointer; }
+        </style>
+    </head>
+    <body>
+        <h1>Homu build results - <a href="{{repo_url}}/pull/{{pull}}" target="_blank">{{repo_label}}#{{pull}}</a></h2>
+
+
+        <table id="results">
+            <thead>
+                <tr>
+                    <th class="hide">Sort key</th>
+                    <th>Builder</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+
+            <tbody>
+                {% for builder in builders %}
+                <tr>
+                    <td class="hide">{{loop.index}}</td>
+                    <td>{{builder.name}}</td>
+                    <td class="{{builder.result}}"><a href="{{builder.url}}">{{builder.result}}</a></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        </script>
+    </body>
+</html>

--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -75,7 +75,13 @@
                     <td><a href="{{state.repo_url}}">{{state.repo_label}}</a></td>
                     {% endif %}
                     <td><a href="{{state.url}}">{{state.num}}</a></td>
-                    <td class="{{state.status}}">{{state.status}}{{state.status_ext}}</td>
+                    <td class="{{state.status}}">
+                        {% if state.status == "pending" or state.status == "failure" or state.status == "success" %}
+                            <a href="../results/{{state.repo_label}}/{{state.num}}">{{state.status}}{{state.status_ext}}</a>
+                        {% else %}
+                            {{state.status}}{{state.status_ext}}
+                        {% endif %}
+                    </td>
                     <td class="{{state.mergeable}}">{{state.mergeable}}</td>
                     <td>{{state.title}}</td>
                     <td>{{state.head_ref}}</td>

--- a/homu/server.py
+++ b/homu/server.py
@@ -66,6 +66,39 @@ def index():
                                          for label in sorted(g.repos)])
 
 
+@get('/results/<repo_label:path>/<pull:int>')
+def result(repo_label, pull):
+    if repo_label not in g.states:
+        abort(404, 'No such repository: {}'.format(repo_label))
+    states = [state for state in g.states[repo_label].values()
+              if state.num == pull]
+    if len(states) == 0:
+        abort(204, 'No build results for pull request {}'.format(pull))
+
+    state = states[0]
+    builders = []
+    repo_url = 'https://github.com/{}/{}'.format(
+        g.cfg['repo'][repo_label]['owner'],
+        g.cfg['repo'][repo_label]['name'])
+    for (builder, data) in state.build_res.items():
+        result = "pending"
+        if data['res'] is not None:
+            result = "success" if data['res'] else "failed"
+
+        if not data['url']:
+            # This happens to old try builds
+            abort(204, 'No build results for pull request {}'.format(pull))
+
+        builders.append({
+            'url': data['url'],
+            'result': result,
+            'name': builder,
+        })
+
+    return g.tpls['build_res'].render(repo_label=repo_label, repo_url=repo_url,
+                                      builders=builders, pull=pull)
+
+
 @get('/queue/<repo_label:path>')
 def queue(repo_label):
     logger = g.logger.getChild('queue')
@@ -781,6 +814,7 @@ def start(cfg, states, queue_handler, repo_cfgs, repos, logger,
     tpls = {}
     tpls['index'] = env.get_template('index.html')
     tpls['queue'] = env.get_template('queue.html')
+    tpls['build_res'] = env.get_template('build_res.html')
 
     g.cfg = cfg
     g.states = states


### PR DESCRIPTION
Currently we get this by going to the buildbot grid, but if you're not on the latest five builds, you have to scroll through the waterfall, which is annoying.

Whipped this together as I was waiting for buildbot. Completely untested.


cc @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/169)
<!-- Reviewable:end -->
