### PR TITLE
Quick fix for homu timeout on try (fixes #903)

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -1023,10 +1023,10 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
         else:
             builders += repo_cfg['buildbot']['builders']
         only_status_builders = False
-    if 'travis' in repo_cfg:
+    if 'travis' in repo_cfg and not state.try_choose:
         builders += ['travis']
         only_status_builders = False
-    if 'status' in repo_cfg:
+    if 'status' in repo_cfg and not state.try_choose:
         found_travis_context = False
         for key, value in repo_cfg['status'].items():
             context = value.get('context')


### PR DESCRIPTION
Homu unconditionally waits on non-buildbot builders on a try build, which is fine except on a try_choose build it shouldn't.

The proper fix is to break `try` support out of the buildbot code here so that try choosers can be status builders too, which I'll do sometime later.


r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/174)
<!-- Reviewable:end -->
