### PR TITLE
Use None, not False, for try_choose default value

### DIFF
--- a/homu/action.py
+++ b/homu/action.py
@@ -204,7 +204,7 @@ def review_approved(state, realtime, approver, username,
     if sha_cmp(sha, state.head_sha):
         state.approved_by = approver
         state.try_ = False
-        state.try_choose = False
+        state.try_choose = None
         state.set_status('')
 
         state.save()


### PR DESCRIPTION
False gets stored as 0

fixes #176

I also ran `update table pull set try_choose=null where try_choose=0;`
on the database to clean up things affected by this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/177)
<!-- Reviewable:end -->
