### PR TITLE
Revert "Quick fix for homu timeout on try (fixes #903)"

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -1023,10 +1023,10 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
         else:
             builders += repo_cfg['buildbot']['builders']
         only_status_builders = False
-    if 'travis' in repo_cfg and not state.try_choose:
+    if 'travis' in repo_cfg:
         builders += ['travis']
         only_status_builders = False
-    if 'status' in repo_cfg and not state.try_choose:
+    if 'status' in repo_cfg:
         found_travis_context = False
         for key, value in repo_cfg['status'].items():
             context = value.get('context')


### PR DESCRIPTION
This reverts commit 755c02c375973042be854389058bfe590d9b2cc9.

The reverted commit was a fix for https://github.com/servo/saltfs/issues/903, but that issue is also fixed by https://github.com/servo/servo/pull/22426: if `.taskcluster.yml` is configured with at least one task, then taskcluster-github will set the status that Homu is waiting for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/184)
<!-- Reviewable:end -->
