### PR TITLE
Make homu listen to commands in PR review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the name of the repository you are configuring homu for.
    - Payload URL: `http://HOST:PORT/github`
    - Content type: `application/json`
    - Secret: The same as `repo.NAME.github.secret` in `cfg.toml`
-   - Events: `Issue Comment`, `Pull Request`, `Push`, `Status`, `Check runs`
+   - Events: `Issue Comment`, `Pull Request`, `Pull Request Review Comments`, `Push`, `Status`, `Check runs`
 
 6. Add a Webhook to your continuous integration service, if necessary. You don't
    need this if using Travis/Appveyor.

--- a/homu/server.py
+++ b/homu/server.py
@@ -350,7 +350,36 @@ def github():
                     state.save()
 
                     g.queue_handler()
+    elif event_type == 'pull_request_review':
+        action = info['action']
+        commit_id = info['review']['commit_id']
+        head_sha = info['pull_request']['head']['sha']
 
+        if action == 'submitted' and commit_id == head_sha:
+            pull_num = info['pull_request']['number']
+            body = info['review']['body']
+            username = info['sender']['login']
+
+            state = g.states[repo_label].get(pull_num)
+            if state:
+                state.title = info['pull_request']['title']
+                state.body = info['pull_request']['body']
+
+                if parse_commands(
+                        g.cfg,
+                        body,
+                        username,
+                        repo_cfg,
+                        state,
+                        g.my_username,
+                        g.db,
+                        g.states,
+                        realtime=True,
+                        sha=commit_id,
+                ):
+                    state.save()
+
+                    g.queue_handler()
     elif event_type == 'pull_request':
         action = info['action']
         pull_num = info['number']


### PR DESCRIPTION
This PR adds support for pull_request_review events to listen for commands in
the main PR review comment. GitHub sends these separately from the line level
comments as part of a review. The logic is almost identical to the other cases
except for the specific event and action and location of some metadata which
changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/197)
<!-- Reviewable:end -->
