### PR TITLE
Don't fall back to a full try if an nonexistent trychooser is requested.

### DIFF
--- a/homu/action.py
+++ b/homu/action.py
@@ -66,11 +66,9 @@ def rollup(state, word):
 
 
 def _try(state, word, realtime, repo_cfg, choose=None):
-    state.try_ = word == 'try'
-    state.merge_sha = ''
-    state.init_build_res([])
+    is_try = word == 'try'
     state.try_choose = None
-    if choose and state.try_:
+    if choose and is_try:
         try:
             if choose in repo_cfg['buildbot']['try_choosers']:
                 state.try_choose = choose
@@ -80,11 +78,16 @@ def _try(state, word, realtime, repo_cfg, choose=None):
                     .format(choose,
                         ", ".join(repo_cfg['buildbot']['try_choosers'].keys()))
                 )
+                return
         except KeyError:
             if realtime:
                 state.add_comment(
                     ':slightly_frowning_face: This repo does not have try choosers set up'  # noqa
                 )
+
+    state.try_ = is_try
+    state.merge_sha = ''
+    state.init_build_res([])
     state.save()
     if state.try_:
         # `try-` just resets the `try` bit and doesn't correspond to

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -94,11 +94,10 @@ class TestAction(unittest.TestCase):
     def test_try_chooser_not_found(self, MockPullReqState):
         state = MockPullReqState()
         action._try(state, 'try', True, TRY_CHOOSER_CONFIG, choose="foo")
-        self.assertTrue(state.try_)
         self.assertEqual(state.try_choose, None)
-        state.init_build_res.assert_called_once_with([])
-        state.save.assert_called_once_with()
-        state.change_labels.assert_called_once_with(LabelEvent.TRY)
+        state.init_build_res.assert_not_called()
+        state.save.assert_not_called()
+        state.change_labels.assert_not_called()
         state.add_comment.assert_called_once_with(":slightly_frowning_face: There is no try chooser foo for this repo, try one of: mac, wpt")
 
     @patch('homu.main.PullReqState')


### PR DESCRIPTION
It's frustrating when I use the wrong name when trying to perform a limited try run in Servo and end up starting a full run instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/homu/199)
<!-- Reviewable:end -->
